### PR TITLE
Changed the pattern naming order

### DIFF
--- a/lib/origen_sim/flow.rb
+++ b/lib/origen_sim/flow.rb
@@ -3,7 +3,7 @@ module OrigenSim
     include OrigenTesters::Flow
 
     def test(name, options = {})
-      pattern = (options[:pattern] || name.try(:pattern) || name).to_s
+      pattern = (name || options[:pattern] || name.try(:pattern)).to_s
 
       Origen.interface.referenced_patterns << pattern
 


### PR DESCRIPTION
If I have func :mpgm_patallp in my flow, the simulation takes the correct pattern. If I use: program :allp, type: :mass however, it will use options[:pattern] = allp

When this goes to origen_sim/flow.rb:

 pattern = (options[:pattern] || name.try(:pattern) || name).to_s

It takes the first argument and the content of pattern is now "allp" and information is lost. Since "allp" is  not a method in my controller, the execution crashes. 

Changing this order fixes it for me. I can now define my flow with both
 program :allp, type: :mass
and
func :mpgm_patallp

I don't know how this might affect other flows however.