### PR TITLE
Fast simulation option (irun)

### DIFF
--- a/config/shared_commands.rb
+++ b/config/shared_commands.rb
@@ -1,9 +1,16 @@
 # The requested command is passed in here as @command
 case @command
 
+when 'generate'
+  Origen.log.info 'FAST SIMULATION'
+  $use_fast_probe_depth = false
+  @application_options << ["--fast", "Fast simulation, minimum probe depth"]
+  $use_fast_probe_depth = true if ARGV.include?('--fast')
+
 when "origen_sim:build", "sim:build"
   require "origen_sim/commands/build"
   exit 0
+
 else
   @plugin_commands << <<-EOT
  sim:build       Build the simulation object for the current/given target

--- a/config/shared_commands.rb
+++ b/config/shared_commands.rb
@@ -2,7 +2,6 @@
 case @command
 
 when 'generate'
-  Origen.log.info 'FAST SIMULATION'
   $use_fast_probe_depth = false
   @application_options << ["--fast", "Fast simulation, minimum probe depth"]
   $use_fast_probe_depth = true if ARGV.include?('--fast')

--- a/lib/origen_sim/simulator.rb
+++ b/lib/origen_sim/simulator.rb
@@ -129,15 +129,26 @@ module OrigenSim
                                    output:            tmp_dir,
                                    check_for_changes: false,
                                    quiet:             true,
-                                   options:           { dir: wave_dir, force: config[:force], setup: config[:setup] },
+                                   options:           { dir: wave_dir, force: config[:force], setup: config[:setup], depth: :all },
                                    output_file_name:  "#{id}.tcl"
+        end
+        input_file_fast = "#{tmp_dir}/#{id}_fast.tcl"
+        if $use_fast_probe_depth
+          fast_probe_depth = config[:fast_probe_depth] || 1
+          Origen.app.runner.launch action:            :compile,
+                                   files:             "#{Origen.root!}/templates/probe.tcl.erb",
+                                   output:            tmp_dir,
+                                   check_for_changes: false,
+                                   quiet:             true,
+                                   options:           { dir: wave_dir, force: config[:force], setup: config[:setup], depth: fast_probe_depth },
+                                   output_file_name:  "#{id}_fast.tcl"
         end
         wave_dir  # Ensure this exists since it won't be referenced above if the
         # input file is already generated
 
         cmd = configuration[:irun] || 'irun'
         cmd += " -r origen -snapshot origen +socket+#{socket_id}"
-        cmd += " -input #{input_file}"
+        cmd += $use_fast_probe_depth ? " -input #{input_file_fast}" : " -input #{input_file}"
         cmd += " -nclibdirpath #{compiled_dir}"
       end
       cmd

--- a/templates/probe.tcl.erb
+++ b/templates/probe.tcl.erb
@@ -1,5 +1,5 @@
 database -open waves -into <%= options[:dir] %> -default -event
-probe -create -shm origen -depth all -database waves
+probe -create -shm origen -depth <%= options[:depth] %> -database waves
 #probe -create -assertions -transaction origen -depth all -database waves
 
 % Hash(options[:force]).each do |net, value|


### PR DESCRIPTION
Allows custom probe depth level for irun simulation that can be activated with command line option, **--fast**.  If **--fast** option is used but the configuration option hasn't been specified,, depth will default to 1.

```ruby
OrigenSim::Tester.new vendor: :cadence, fast_probe_depth: 1     # use depth of 1 for fast switch

$ origen g <pattern_name> --fast
```