### PR TITLE
Better logging and Process Reaping

### DIFF
--- a/lib/origen_sim.rb
+++ b/lib/origen_sim.rb
@@ -43,6 +43,17 @@ module OrigenSim
     @error_strings = val
   end
 
+  def self.error_string_exceptions
+    @error_string_exceptions ||= []
+  end
+
+  def self.error_string_exceptions=(val)
+    unless val.is_a?(Array)
+      fail 'OrigenSim.error_string_exceptions can only be set to an array of string values!'
+    end
+    @error_string_exceptions = val
+  end
+
   def self.log_strings
     @log_strings ||= []
   end
@@ -52,6 +63,14 @@ module OrigenSim
       fail 'OrigenSim.log_strings can only be set to an array of string values!'
     end
     @log_strings = val
+  end
+
+  def self.fail_on_stderr=(val)
+    @fail_on_stderr = val
+  end
+
+  def self.fail_on_stderr
+    defined?(@fail_on_stderr) ? @fail_on_stderr : true
   end
 end
 OrigenSim.__instantiate_simulator__

--- a/lib/origen_sim.rb
+++ b/lib/origen_sim.rb
@@ -23,5 +23,35 @@ module OrigenSim
   def self.simulator
     @simulator
   end
+
+  def self.verbose=(val)
+    @verbose = val
+  end
+
+  def self.verbose?
+    !!@verbose
+  end
+
+  def self.error_strings
+    @error_strings ||= ['ERROR']
+  end
+
+  def self.error_strings=(val)
+    unless val.is_a?(Array)
+      fail 'OrigenSim.error_strings can only be set to an array of string values!'
+    end
+    @error_strings = val
+  end
+
+  def self.log_strings
+    @log_strings ||= []
+  end
+
+  def self.log_strings=(val)
+    unless val.is_a?(Array)
+      fail 'OrigenSim.log_strings can only be set to an array of string values!'
+    end
+    @log_strings = val
+  end
 end
 OrigenSim.__instantiate_simulator__

--- a/lib/origen_sim/simulator.rb
+++ b/lib/origen_sim/simulator.rb
@@ -537,7 +537,8 @@ module OrigenSim
     def read_sim_output
       while stdout.ready?
         line = stdout.gets.chomp
-        if OrigenSim.error_strings.any? { |s| line =~ /#{s}/ }
+        if OrigenSim.error_strings.any? { |s| line =~ /#{s}/ } &&
+           !OrigenSim.error_string_exceptions.any? { |s| line =~ /#{s}/ }
           @simulator_logged_errors = true
           Origen.log.error line
         else
@@ -550,7 +551,7 @@ module OrigenSim
         end
       end
       while stderr.ready?
-        @simulator_logged_errors = true
+        @simulator_logged_errors = true if OrigenSim.fail_on_stderr
         Origen.log.error stderr.gets.chomp
       end
     end


### PR DESCRIPTION
This PR improves logging and should eliminate zombie simulator processes.

Previously, output from the simulator was not really captured by Origen, though it would display all output if you ran with -d and hide it all otherwise.
Now all of the output is captured by Origen, thereby allowing it to be considered when determining the simulation pass/fail result and giving the application some control over what they want to see.

Now by default, the simulation will be reported as a failure if the simulator log contains the string "ERROR", or if it writes anything to STDERR.
For a simulation now to be considered a pass, there must be no vector miscompares AND no error messages in the logs.

An application can add additional error strings by pushing into the following array (note that it already contains ["ERROR"] by default):

~~~ruby
OrigenSim.error_strings << "FATAL!"
~~~

You can also assign a new array if you want to remove the "ERROR" string condition, this will effectively turn off this feature:

~~~ruby
OrigenSim.error_strings = []
~~~

A similar array exists for logging, but it will not affect the pass/fail result:

~~~ruby
OrigenSim.log_strings << "ASSERT"  # Show me all lines containing 'ASSERT'
~~~

As before, when Origen is run in debug mode with the -d switch, all simulator output will be shown.

Since all simulator output is now processed by Origen, it will now appear in the Origen logs, i.e. log/last.txt

Additionally, the way that the simulator process is monitored has been overhauled, since the old way still had a tendency to leave zombie simulator processes depending on how the main Origen thread shutdown.

Previously, the master Origen process tried to monitor the process ID (PID) of the simulator process and kill it before Origen shut down.

Now, the Ruby sub-process which runs the simulator will listen for a heartbeat from the main Origen process and if it stops, it will kill the simulator.
So the simulator processes should be self-killing now if the Origen master process ends without properly shutting down the simulator.

As always, there is no documentation of this yet apart from in this PR, an OrigenSim documentation effort will follow later this year.





