### PR TITLE
Generic socket

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     origen_sim (0.8.0)
-      origen (>= 0.32)
+      origen (>= 0.33.1)
       origen_testers
       origen_verilog (>= 0.3.1)
 
@@ -39,7 +39,7 @@ GEM
     dentaku (2.0.11)
     diff-lcs (1.3)
     docile (1.1.5)
-    faraday (0.14.0)
+    faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
     geminabox (0.12.4)
       builder
@@ -49,7 +49,7 @@ GEM
       sinatra (>= 1.2.7)
     gems (0.8.3)
     highline (1.7.10)
-    httparty (0.16.1)
+    httparty (0.16.2)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     i18n (0.9.5)
@@ -58,6 +58,7 @@ GEM
     kramdown (1.16.2)
     log4r (1.1.10)
     method_source (0.9.0)
+    mini_portile2 (2.3.0)
     minitest (5.11.3)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -65,7 +66,9 @@ GEM
       cri (~> 2.3)
     nesty (1.0.2)
     net-ldap (0.16.1)
-    origen (0.33.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
+    origen (0.33.1)
       activesupport (~> 4.1)
       bundler (~> 1.7)
       coderay (~> 1.1)
@@ -80,6 +83,7 @@ GEM
       log4r (~> 1.1.10, ~> 1.1)
       nanoc (~> 3.7)
       net-ldap (~> 0.13)
+      nokogiri (>= 1.7.2)
       pry (~> 0.10)
       rake (~> 10)
       rspec (~> 3)
@@ -102,14 +106,14 @@ GEM
     origen_verilog (0.3.1)
       ast (~> 2)
       treetop
-    parser (2.5.0.5)
+    parser (2.5.1.0)
       ast (~> 2.4.0)
     polyglot (0.3.5)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rack (1.6.9)
+    rack (1.6.10)
     rack-protection (1.5.5)
       rack
     rainbow (2.2.2)

--- a/README.md
+++ b/README.md
@@ -71,9 +71,37 @@ origen
 The driver contains a number of registers which are written to directly by the VPI process, allowing it to drive or expect a given data value (stored in <code>origen.pins.\<pin\>.data</code>) by writing a 1 to <code>origen.pins.\<pin\>.drive</code> or <code>origen.pins.\<pin\>.compare respectively</code>.
 If the value being driven by the pin does match the expect data during a cycle, then an error signal will be asserted by the driver and this will increment an error counter that lives in <code>origen.debug.errors[31:0]</code>.
 
+#### Supported Toolchains
 
+##### Cadence
+
+##### Generic
+
+Generic toolchains allow you to use a tool that is not support out of the box by <code>OrigenSim</code>. For these, it is your responsiblity, using the <code>pre_run_start_block</code> and the
+<code>post_run_start_block</code> to start the VPI process, but this allows for arbitrary commands to be run, with the context of the simulation, and allow end users to still use <code>origen g</code>
+as if with a <code>OrigenSim</code> supported toolchain.
+
+An example of such a setup could be:
+
+~~~ruby
+OrigenSim.generic do |sim|
+  sim.startup_timeout 300
+  sim.post_run_start do |s|
+    # At this point, the socket is attempting to connect to the VPI
+    # The below command will start up the VPI
+    `path/to/custom/sim/script +socket+#{s.socket_id}`
+  end
+end
+~~~
+
+
+#### Configuring The Testbench
+
+The testbench can be instantiated with configuration options.
 
 ### The VPI Extension
+
+#### Configuring The VPI
 
 ### Register Syncing
 

--- a/README.md
+++ b/README.md
@@ -71,21 +71,33 @@ origen
 The driver contains a number of registers which are written to directly by the VPI process, allowing it to drive or expect a given data value (stored in <code>origen.pins.\<pin\>.data</code>) by writing a 1 to <code>origen.pins.\<pin\>.drive</code> or <code>origen.pins.\<pin\>.compare respectively</code>.
 If the value being driven by the pin does match the expect data during a cycle, then an error signal will be asserted by the driver and this will increment an error counter that lives in <code>origen.debug.errors[31:0]</code>.
 
-#### Supported Toolchains
+### Toolchains
 
-##### Cadence
+Running the testbench along with the VPI takes place within the toolchain. Different toolchains have different setups
+and different compilation and running procedures. Below is summary of some of the supported toolchains and notes on how
+to use them with OrigenSim.
 
-##### Generic
+<anchor>cadence</anchor>
+<anchor>irun</anchor>
+#### Cadence (irun)
 
-Generic toolchains allow you to use a tool that is not support out of the box by <code>OrigenSim</code>. For these, it is your responsiblity, using the <code>pre_run_start_block</code> and the
-<code>post_run_start_block</code> to start the VPI process, but this allows for arbitrary commands to be run, with the context of the simulation, and allow end users to still use <code>origen g</code>
-as if with a <code>OrigenSim</code> supported toolchain.
+#### Synopsis
+
+#### Generic
+
+Generic toolchains allow you to use a tool that is not support out of the box by <code>OrigenSim</code>. For these, it 
+is your responsiblity, using the <code>pre_run_start_block</code> and the
+<code>post_run_start_block</code> to start the VPI process, however, this allows for arbitrary commands to be run, 
+within the context of the simulation, and allow end users to still use <code>origen g</code>
+as if with an <code>OrigenSim</code> supported toolchain.
 
 An example of such a setup could be:
 
 ~~~ruby
 OrigenSim.generic do |sim|
+  # Set a 5 minute connection timeout
   sim.startup_timeout 300
+
   sim.post_run_start do |s|
     # At this point, the socket is attempting to connect to the VPI
     # The below command will start up the VPI
@@ -94,10 +106,21 @@ OrigenSim.generic do |sim|
 end
 ~~~
 
+### Configuring The Toolchain (Vendor)
 
-#### Configuring The Testbench
+When you define a toolchain, you can pass in additional arguments to customize the toolchain and how OrigenSim interacts
+with the toolchain.
 
-The testbench can be instantiated with configuration options.
+A non-exhaustive list (to be updated in the future) is below:
+
+* testbench_top: Defines the testbench name if different from <code>origen</code>.
+* view_waveform_cmd: Required for generic toolchains - prints out this statement following a simulation instructing the
+user on how to open the waveforms for viewing. For supported toolchains, this is already provided, but can be overwritten.
+* startup_timeout: Defines how long (in seconds) OrigenSim will wait for VPI interaction on the socket before it terminates
+and returns an error.
+* pre_run_start_block: Block that is run <b>before</b> OrigenSim begins connecting to the testbench VPI.
+* post_run_start_block: Block it that is run <b>after</b> OrigenSim begins connecting to the testbench VPI. This is
+required for the generic toolchain.
 
 ### The VPI Extension
 

--- a/config/shared_commands.rb
+++ b/config/shared_commands.rb
@@ -26,10 +26,10 @@ when "sim:unpack"
   OrigenSim::Commands::Pack.unpack
   exit 0
 
-when "sim:list"
-  require "#{Origen.root!}/lib/origen_sim/commands/pack"
-  OrigenSim::Commands::Pack.list
-  exit 0
+#when "sim:list"
+#  require "#{Origen.root!}/lib/origen_sim/commands/pack"
+#  OrigenSim::Commands::Pack.list
+#  exit 0
 
 else
   @plugin_commands << <<-EOT

--- a/config/shared_commands.rb
+++ b/config/shared_commands.rb
@@ -16,10 +16,28 @@ when "sim:co", "origen_sim:co"
   require "#{Origen.root!}/lib/origen_sim/commands/co"
   exit 0
 
+when "sim:pack"
+  require "#{Origen.root!}/lib/origen_sim/commands/pack"
+  OrigenSim::Commands::Pack.pack
+  exit 0
+
+when "sim:unpack"
+  require "#{Origen.root!}/lib/origen_sim/commands/pack"
+  OrigenSim::Commands::Pack.unpack
+  exit 0
+
+when "sim:list"
+  require "#{Origen.root!}/lib/origen_sim/commands/pack"
+  OrigenSim::Commands::Pack.list
+  exit 0
+
 else
   @plugin_commands << <<-EOT
  sim:ci       Checkin a simulation snapshot
  sim:co       Checkout a simulation snapshot
+ sim:pack     Packs the snapshot into a compressed directory
+ sim:unpack   Unpacks a snapshot
+ sim:list     List the available snapshot packs
   EOT
 
 end

--- a/ext/bridge.c
+++ b/ext/bridge.c
@@ -83,7 +83,7 @@ static void bridge_define_pin(char * name, char * pin_ix, char * drive_wave_ix, 
   (*pin).capture_en = false;
 
   char * driver = (char *) malloc(strlen(name) + 16);
-  strcpy(driver, "origen.pins.");
+  strcpy(driver, ORIGEN_SIM_TESTBENCH_CAT("pins."));
   strcat(driver, name);
 
   char * data = (char *) malloc(strlen(driver) + 16);
@@ -661,7 +661,7 @@ PLI_INT32 bridge_wait_for_msg(p_cb_data data) {
       // Set Pattern Name
       //   a^atd_ramp_25mhz
       case 'a' :
-        handle = vpi_handle_by_name("origen.debug.pattern", NULL);
+        handle = vpi_handle_by_name(ORIGEN_SIM_TESTBENCH_CAT("debug.pattern"), NULL);
         arg1 = strtok(NULL, "^");
 
         v.format = vpiStringVal;
@@ -686,7 +686,7 @@ PLI_INT32 bridge_wait_for_msg(p_cb_data data) {
       // Set Comment
       //   c^Some comment about the pattern
       case 'c' :
-        handle = vpi_handle_by_name("origen.debug.comments", NULL);
+        handle = vpi_handle_by_name(ORIGEN_SIM_TESTBENCH_CAT("debug.comments"), NULL);
         arg1 = strtok(NULL, "^");
 
         v.format = vpiStringVal;
@@ -710,14 +710,14 @@ PLI_INT32 bridge_wait_for_msg(p_cb_data data) {
         break;
       // Sync enable
       case 'f' :
-        handle = vpi_handle_by_name("origen.pins.sync", NULL);
+        handle = vpi_handle_by_name(ORIGEN_SIM_TESTBENCH_CAT("pins.sync"), NULL);
         v.format = vpiDecStrVal;
         v.value.str = "1";
         vpi_put_value(handle, &v, NULL, vpiNoDelay);
         break;
       // Sync disable
       case 'g' :
-        handle = vpi_handle_by_name("origen.pins.sync", NULL);
+        handle = vpi_handle_by_name(ORIGEN_SIM_TESTBENCH_CAT("pins.sync"), NULL);
         v.format = vpiDecStrVal;
         v.value.str = "0";
         vpi_put_value(handle, &v, NULL, vpiNoDelay);
@@ -751,7 +751,7 @@ static void end_simulation() {
   s_vpi_value v;
 
   // Setting this node will cause the testbench to call $finish
-  handle = vpi_handle_by_name("origen.finish", NULL);
+  handle = vpi_handle_by_name(ORIGEN_SIM_TESTBENCH_CAT("finish"), NULL);
   v.format = vpiDecStrVal;
   v.value.str = "1";
   vpi_put_value(handle, &v, NULL, vpiNoDelay);

--- a/ext/common.h
+++ b/ext/common.h
@@ -11,6 +11,10 @@
 
 #define ENABLE_DEBUG
 
+/// Prepends the testbench name to the signal.
+/// e.g.: TESTBENCH_CAT(pins) => TESTBENCH_NAME.pins => origen.pins
+#define ORIGEN_SIM_TESTBENCH_CAT(signal) ORIGEN_SIM_TESTBENCH_NAME "." signal
+
 #ifdef ENABLE_DEBUG
 /* #define DEBUG(fmt, args...) fprintf(stderr, "DEBUG: %s:%d:%s(): " fmt, \
     __FILE__, __LINE__, __func__, ##args) */

--- a/ext/defines.h.erb
+++ b/ext/defines.h.erb
@@ -2,5 +2,6 @@
 #define DEFINES_H
 
 #define ORIGEN_SIM_VERSION "<%= OrigenSim::VERSION %>"
+#define ORIGEN_SIM_TESTBENCH_NAME "<%= options[:testbench_name] %>"
 
 #endif

--- a/ext/origen.c
+++ b/ext/origen.c
@@ -85,6 +85,14 @@ PLI_INT32 origen_shutdown(p_cb_data data) {
   return 0;
 }
 
+/// Function to call the init PLI's init function
+/// Some toolchains will call this automatically, some will not
+/// Available here for those which do not automatically call init() for each PLI 
+PLI_INT32 bootstrap(p_cb_data data) {
+  vpi_printf("Origen Bootstrap Called!\n");
+  init();
+  return 0;
+}
 
 ///
 /// Registers a very basic VPI callback with reason and handler.

--- a/lib/origen_sim.rb
+++ b/lib/origen_sim.rb
@@ -23,5 +23,22 @@ module OrigenSim
   def self.simulator
     @simulator
   end
+
+  # Provide some shortcut methods to set the vendor
+  def self.generic(options={}, &block)
+    Tester.new(options.merge({vendor: :generic}), &block)
+  end
+
+  def self.cadence(options={}, &block)
+    Tester.new(options.merge({vendor: :cadence}), &block)
+  end
+
+  def self.synopsys(optoins={}, &block)
+    Tester.new(options.merge({vendor: :synopsys}), &block)
+  end
+
+  def self.icarus(options={}, &block)
+    Tester.new(options.merge({vendor: :icarus}), &block)
+  end
 end
 OrigenSim.__instantiate_simulator__

--- a/lib/origen_sim.rb
+++ b/lib/origen_sim.rb
@@ -25,20 +25,20 @@ module OrigenSim
   end
 
   # Provide some shortcut methods to set the vendor
-  def self.generic(options={}, &block)
-    Tester.new(options.merge({vendor: :generic}), &block)
+  def self.generic(options = {}, &block)
+    Tester.new(options.merge(vendor: :generic), &block)
   end
 
-  def self.cadence(options={}, &block)
-    Tester.new(options.merge({vendor: :cadence}), &block)
+  def self.cadence(options = {}, &block)
+    Tester.new(options.merge(vendor: :cadence), &block)
   end
 
-  def self.synopsys(optoins={}, &block)
-    Tester.new(options.merge({vendor: :synopsys}), &block)
+  def self.synopsys(optoins = {}, &block)
+    Tester.new(options.merge(vendor: :synopsys), &block)
   end
 
-  def self.icarus(options={}, &block)
-    Tester.new(options.merge({vendor: :icarus}), &block)
+  def self.icarus(options = {}, &block)
+    Tester.new(options.merge(vendor: :icarus), &block)
   end
 end
 OrigenSim.__instantiate_simulator__

--- a/lib/origen_sim/commands/build.rb
+++ b/lib/origen_sim/commands/build.rb
@@ -3,7 +3,7 @@ require 'origen_sim'
 require_relative '../../../config/version'
 require 'origen_verilog'
 
-options = { source_dirs: [] }
+options = { source_dirs: [], testbench_name: 'origen' }
 
 # App options are options that the application can supply to extend this command
 app_options = @application_options || []
@@ -18,6 +18,7 @@ Usage: origen sim:build TOP_LEVEL_VERILOG_FILE [options]
   EOT
   opts.on('-o', '--output DIR', String, 'Override the default output directory') { |t| options[:output] = t }
   opts.on('-t', '--top NAME', String, 'Specify the top-level Verilog module name if OrigenSim can\'t work it out') { |t| options[:top_level_name] = t }
+  opts.on('--testbench NAME', String, 'Specify the testbench name if different from \'origen\'') { |t| options[:testbench_name] = t }
   opts.on('-s', '--source_dir PATH', 'Directories to look for include files in (the directory containing the top-level is already considered)') do |path|
     options[:source_dirs] << path
   end
@@ -86,7 +87,8 @@ Origen.app.runner.launch action:            :compile,
                          files:             "#{Origen.root!}/ext",
                          output:            output_directory,
                          check_for_changes: false,
-                         quiet:             true
+                         quiet:             true,
+                         options:           options
 
 dut.export(rtl_top_module, dir: "#{output_directory}", namespace: nil)
 

--- a/lib/origen_sim/commands/pack.rb
+++ b/lib/origen_sim/commands/pack.rb
@@ -4,36 +4,34 @@ module OrigenSim
       # Note, making this a module instead of straight code so it can be called
       # programatically to auto-unpack a snapshot.
 
-      def self.pack(options={})
+      def self.pack(options = {})
         testbench = "#{Origen.app.root}/simulation"
         unless Dir.exist?(testbench)
           fail "Could not find path #{testbench}/#{ARGV[0]}"
         end
-  
+
         FileUtils.mkdir("#{Origen.app.root}/simulation/static") unless Dir.exist?("#{Origen.app.root}/simulation/static")
-  
+
         output = "#{Origen.app.root}/simulation/static/#{ARGV[0]}.tar.gz"
         puts "Packing #{testbench} into #{output}..."
         system "tar vczf #{output} -C #{testbench} #{Origen.target.name}"
       end
 
-      def self.unpack(options={})
+      def self.unpack(options = {})
         testbench = "#{Origen.app.root}/simulation/static/#{ARGV[0]}.tar.gz"
         unless File.exist?(testbench)
           fail "Could not find #{testbench}"
         end
-  
+
         output = "#{Origen.app.root}/simulation"
         FileUtils.mkdir(output) unless Dir.exist?(output)
-  
+
         puts "Unpakcing Testbench into #{output}"
         system "tar vxzf #{testbench} -C #{output} #{ARGV[0]}"
       end
 
-      def self.list(options={})
+      def self.list(options = {})
       end
-
     end
   end
 end
-

--- a/lib/origen_sim/commands/pack.rb
+++ b/lib/origen_sim/commands/pack.rb
@@ -1,0 +1,39 @@
+module OrigenSim
+  module Commands
+    module Pack
+      # Note, making this a module instead of straight code so it can be called
+      # programatically to auto-unpack a snapshot.
+
+      def self.pack(options={})
+        testbench = "#{Origen.app.root}/simulation"
+        unless Dir.exist?(testbench)
+          fail "Could not find path #{testbench}/#{ARGV[0]}"
+        end
+  
+        FileUtils.mkdir("#{Origen.app.root}/simulation/static") unless Dir.exist?("#{Origen.app.root}/simulation/static")
+  
+        output = "#{Origen.app.root}/simulation/static/#{ARGV[0]}.tar.gz"
+        puts "Packing #{testbench} into #{output}..."
+        system "tar vczf #{output} -C #{testbench} #{Origen.target.name}"
+      end
+
+      def self.unpack(options={})
+        testbench = "#{Origen.app.root}/simulation/static/#{ARGV[0]}.tar.gz"
+        unless File.exist?(testbench)
+          fail "Could not find #{testbench}"
+        end
+  
+        output = "#{Origen.app.root}/simulation"
+        FileUtils.mkdir(output) unless Dir.exist?(output)
+  
+        puts "Unpakcing Testbench into #{output}"
+        system "tar vxzf #{testbench} -C #{output} #{ARGV[0]}"
+      end
+
+      def self.list(options={})
+      end
+
+    end
+  end
+end
+

--- a/lib/origen_sim/simulator.rb
+++ b/lib/origen_sim/simulator.rb
@@ -6,7 +6,7 @@ module OrigenSim
   class Simulator
     include Origen::PersistentCallbacks
 
-    VENDORS = [:icarus, :cadence, :synopsys]
+    VENDORS = [:icarus, :cadence, :synopsys, :generic]
 
     attr_reader :socket, :failed, :configuration
     alias_method :config, :configuration
@@ -20,6 +20,22 @@ module OrigenSim
       else
         put('d^0')
       end
+    end
+
+    def testbench_top
+      config[:testbench_top] || 'origen'
+    end
+
+    def rtl_top
+      config[:rtl_top] || 'dut'
+    end
+
+    def pre_run_start_block
+      config[:pre_run_start_block]
+    end
+
+    def post_run_start_block
+      config[:post_run_start_block]
     end
 
     def fetch_simulation_objects(options = {})
@@ -53,7 +69,7 @@ module OrigenSim
         if !File.exist?(compiled_dir) ||
            (File.exist?(compiled_dir) && Dir.entries(compiled_dir).size <= 2)
           puts "There is no previously compiled simulation object in: #{compiled_dir}"
-          exit 1
+          #exit 1
         end
       end
     ensure
@@ -83,12 +99,13 @@ module OrigenSim
       FileUtils.rm_rf tmp_dir if File.exist?(tmp_dir)
     end
 
-    def configure(options)
+    def configure(options, &block)
       fail 'A vendor must be supplied, e.g. OrigenSim::Tester.new(vendor: :icarus)' unless options[:vendor]
       unless VENDORS.include?(options[:vendor])
         fail "Unknown vendor #{options[:vendor]}, valid values are: #{VENDORS.map { |v| ':' + v.to_s }.join(', ')}"
       end
       @configuration = options
+      @setup_block = block
       @tmp_dir = nil
     end
 
@@ -214,7 +231,11 @@ module OrigenSim
 
       when :synopsys
         cmd = "#{compiled_dir}/simv +socket+#{socket_id} -vpd_file origen.vpd"
-
+      
+      when :generic
+        #cmd = "echo #{socket_id}"
+        cmd = ':' # nop command. don't do anything here for generic tester. should be setup using pre/post run blocks
+      
       else
         fail "Run cmd not defined yet for simulator #{config[:vendor]}"
 
@@ -274,6 +295,13 @@ module OrigenSim
       verbose = Origen.debugger_enabled?
       cmd = run_cmd + ' & echo \$!'
 
+      # If the user supplied additional setup to be run, prior to the run call occuring, do this now.
+      if pre_run_start_block
+        Origen.log.info "Calling User-Specified pre_run_start Block..."
+        pre_run_start_block.call(self) if pre_run_start_block
+        Origen.log.info "Setup Block Finished!"
+      end
+
       launch_simulator = %(
         require 'open3'
 
@@ -301,6 +329,15 @@ module OrigenSim
 
       simulator_parent_process = spawn("ruby -e \"#{launch_simulator}\"")
       Process.detach(simulator_parent_process)
+
+      # At this point, the simulator is trying to run, i.e., 'run has started'.
+      # If we have a block to run before we wait for the simulator, run that, then wait on it.
+      # If the user supplied additional setup to be run, do that now.
+      if post_run_start_block
+        Origen.log.info "Calling User-Specified post_run_start Block..."
+        post_run_start_block.call(self) if post_run_start_block
+        Origen.log.info "Setup Block Finished!"
+      end
 
       timeout_connection(config[:startup_timeout] || 60) do
         @socket = server.accept
@@ -488,7 +525,7 @@ module OrigenSim
 
     # Returns the current simulation error count
     def error_count
-      peek('origen.debug.errors').to_i
+      peek("#{testbench_top}.debug.errors").to_i
     end
 
     # Returns the current value of the given net, or nil if the given path does not
@@ -546,7 +583,6 @@ module OrigenSim
 
         v = peek(path)
         return nil unless v
-
         # Setting a range of bits
         if lsb
           upper = v >> (msb + 1)
@@ -576,6 +612,7 @@ module OrigenSim
       end
 
       sync_up
+      puts "Net: #{net}: Value #{value}"
       put("b^#{clean(net)}^#{value}")
     end
 

--- a/lib/origen_sim/simulator.rb
+++ b/lib/origen_sim/simulator.rb
@@ -273,6 +273,19 @@ module OrigenSim
         f = Pathname.new(wave_config_file).relative_path_from(edir.expand_path)
         cmd += " -session #{f}"
         cmd += ' &'
+        
+      when :generic
+        # Since this could be anything, the simulator will need to set this up. But, once it is, we can print it here.
+        if config[:view_waveform_cmd]
+          cmd = config[:view_waveform_cmd] 
+        else
+          Origen.log.warn 'OrigenSim cannot provide a view-waveform command for a :generic vendor.'
+          Origen.log.warn 'Please supply a view-waveform command though the :view_waveform_cmd option during the OrigenSim::Generic instantiation.'
+        end
+      
+      else
+        # Print a warning stating an unknown vendor was reached here
+        Origen.log.warn "OrigenSim does not know the command to view waveforms for vendor :#{config[:vendor]}!"
 
       end
       cmd

--- a/lib/origen_sim/simulator.rb
+++ b/lib/origen_sim/simulator.rb
@@ -69,7 +69,7 @@ module OrigenSim
         if !File.exist?(compiled_dir) ||
            (File.exist?(compiled_dir) && Dir.entries(compiled_dir).size <= 2)
           puts "There is no previously compiled simulation object in: #{compiled_dir}"
-          #exit 1
+          exit 1
         end
       end
     ensure
@@ -105,7 +105,6 @@ module OrigenSim
         fail "Unknown vendor #{options[:vendor]}, valid values are: #{VENDORS.map { |v| ':' + v.to_s }.join(', ')}"
       end
       @configuration = options
-      @setup_block = block
       @tmp_dir = nil
     end
 
@@ -231,11 +230,11 @@ module OrigenSim
 
       when :synopsys
         cmd = "#{compiled_dir}/simv +socket+#{socket_id} -vpd_file origen.vpd"
-      
+
       when :generic
-        #cmd = "echo #{socket_id}"
+        # cmd = "echo #{socket_id}"
         cmd = ':' # nop command. don't do anything here for generic tester. should be setup using pre/post run blocks
-      
+
       else
         fail "Run cmd not defined yet for simulator #{config[:vendor]}"
 
@@ -273,16 +272,16 @@ module OrigenSim
         f = Pathname.new(wave_config_file).relative_path_from(edir.expand_path)
         cmd += " -session #{f}"
         cmd += ' &'
-        
+
       when :generic
         # Since this could be anything, the simulator will need to set this up. But, once it is, we can print it here.
         if config[:view_waveform_cmd]
-          cmd = config[:view_waveform_cmd] 
+          cmd = config[:view_waveform_cmd]
         else
           Origen.log.warn 'OrigenSim cannot provide a view-waveform command for a :generic vendor.'
           Origen.log.warn 'Please supply a view-waveform command though the :view_waveform_cmd option during the OrigenSim::Generic instantiation.'
         end
-      
+
       else
         # Print a warning stating an unknown vendor was reached here
         Origen.log.warn "OrigenSim does not know the command to view waveforms for vendor :#{config[:vendor]}!"
@@ -310,9 +309,9 @@ module OrigenSim
 
       # If the user supplied additional setup to be run, prior to the run call occuring, do this now.
       if pre_run_start_block
-        Origen.log.info "Calling User-Specified pre_run_start Block..."
+        Origen.log.info 'Calling User-Specified pre_run_start Block...'
         pre_run_start_block.call(self) if pre_run_start_block
-        Origen.log.info "Setup Block Finished!"
+        Origen.log.info 'Setup Block Finished!'
       end
 
       launch_simulator = %(
@@ -347,9 +346,9 @@ module OrigenSim
       # If we have a block to run before we wait for the simulator, run that, then wait on it.
       # If the user supplied additional setup to be run, do that now.
       if post_run_start_block
-        Origen.log.info "Calling User-Specified post_run_start Block..."
+        Origen.log.info 'Calling User-Specified post_run_start Block...'
         post_run_start_block.call(self) if post_run_start_block
-        Origen.log.info "Setup Block Finished!"
+        Origen.log.info 'Setup Block Finished!'
       end
 
       timeout_connection(config[:startup_timeout] || 60) do
@@ -625,7 +624,6 @@ module OrigenSim
       end
 
       sync_up
-      puts "Net: #{net}: Value #{value}"
       put("b^#{clean(net)}^#{value}")
     end
 

--- a/lib/origen_sim/tester.rb
+++ b/lib/origen_sim/tester.rb
@@ -5,8 +5,19 @@ module OrigenSim
 
     TEST_PROGRAM_GENERATOR = OrigenSim::Generator
 
-    def initialize(options = {})
-      simulator.configure(options)
+    def initialize(options = {}, &block)
+      # Use Origen's collector to allow options to be set either from the options hash, or from the block
+      if block_given?
+        collector = Origen::Utility::Collector.new
+        yield collector
+        opts = options.merge(collector.store)
+      else
+        opts = options
+      end
+
+     puts opts
+
+      simulator.configure(opts, &block)
       super()
     end
 

--- a/lib/origen_sim/tester.rb
+++ b/lib/origen_sim/tester.rb
@@ -10,7 +10,7 @@ module OrigenSim
       if block_given?
         collector = Origen::Utility::Collector.new
         yield collector
-        opts = options.merge(collector.store)
+        opts = options.merge(collector.to_hash)
       else
         opts = options
       end

--- a/lib/origen_sim/tester.rb
+++ b/lib/origen_sim/tester.rb
@@ -8,9 +8,7 @@ module OrigenSim
     def initialize(options = {}, &block)
       # Use Origen's collector to allow options to be set either from the options hash, or from the block
       if block_given?
-        collector = Origen::Utility::Collector.new
-        yield collector
-        opts = options.merge(collector.to_hash)
+        opts = Origen::Utility.collector(hash: options, merge_method: :keep_hash, &block).to_hash
       else
         opts = options
       end

--- a/lib/origen_sim/tester.rb
+++ b/lib/origen_sim/tester.rb
@@ -15,8 +15,6 @@ module OrigenSim
         opts = options
       end
 
-     puts opts
-
       simulator.configure(opts, &block)
       super()
     end

--- a/origen_sim.gemspec
+++ b/origen_sim.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Add any gems that your plugin needs to run within a host application
-  spec.add_runtime_dependency "origen", ">= 0.32"
+  spec.add_runtime_dependency "origen", ">= 0.33.1"
   spec.add_runtime_dependency "origen_testers"
   spec.add_runtime_dependency "origen_verilog", ">= 0.3.1"
 end


### PR DESCRIPTION
Added support for configuring an unknown toolchain (vendor). This was developed for ncsim, which, as part of cadence, probably could have its own vendor, but for now, I used it to prototype a generic tester. This requires you to setup at least a <code>post_run_start_block</code> process, which should be system commands (or anything, really) that starts up the testbench and passes it the socket. An example, using <code>ncsim</code>, is:

~~~ruby
OrigenSim.generic(startup_timeout: 900) do |sim|
  sim.testbench_top 'na_origen'
  sim.post_run_start_block do |s|
    pid = Process.spawn("ncsim na_origen -loadpli origen.so:bootstrap +socket+#{s.socket_id}")
    puts "Spawning process: #{pid}"
  end
end
~~~

Updated the README, but plan to do more thorough docs once we start a website for OrigenSim.

A few other, more minor updates:
* Added some shortcut methods to instantiate the tester. E.g., <code>OrigenSim.generic(...)</code> instead of OrigenSim::Tester.new(vendor: :generic, ...)</code> or <code>OrigenSim.cadence(...)</code> instead of <code>OrigenSim::Tester.new(vendor: :cadence, ...)</code>.
* The tester and <code>simulator::configure</code> uses the Collector, with the options taking precedence. So, either hash or block syntax is supported.
* Updated Origen version to use the version with the Collector.
* Added an option to configure the testbench name. This will propagate through all the system calls. <code>origen</code> is the default.
* Added a similar option when using <code>origen sim:build</code>, i.e., <code>origen sim:build --testbench NAME</code> which will compile the VPI using that name. Default is <code>origen</code>.
* Added a <code>pack</code> and <code>unpack</code> method to just compress and uncompress the snapshot without checking it in. Plan to combine with <code>ci/co</code>,  but kept it in for now.
* Added a bootstrap method to the VPI, to be used if the VPI isn't auto-booted (it is in <code>irun</code>, but is not in <code>ncsim</code>.