### PR TITLE
Artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ For example, when the Cadence vendor is used:
 
 ~~~ruby
 Origen.tester.simulator.run_dir
-	#=> "/path/to/the/current/app/tmp/origen_sim/default/cadence"
+  #=> "/path/to/the/current/app/tmp/origen_sim/default/cadence"
 ~~~
 
 #### Artifacts
@@ -235,12 +235,12 @@ simulation process starts. You can customize these directories when instantiatin
 
 ~~~ruby
 OrigenSim::cadence do |sim|
-	# Change the default artifact directory
+  # Change the default artifact directory
   sim.artifact_dir "#{Origen.app.root}/simulation/_testbench_"
 
-	# Change the artifact target location, within the context of the run directory.
+  # Change the artifact target location, within the context of the run directory.
   # NOTE: this is relative to the run_dir. This expands to /path/to/run/dir/_testbench_
-  sim.artifact_run_dir "./_testbench_"
+   sim.artifact_run_dir "./_testbench_"
 end
 ~~~
 
@@ -255,11 +255,11 @@ may take longer. This behavior can be changed however:
 
 ~~~ruby
 OrigenSim::cadence do |sim|
-	# Force all artifacts to be copied
-	artifact_populate_method :copy
+  # Force all artifacts to be copied
+  artifact_populate_method :copy
 	
-	# Force all artifacts to be symlinked
-	artifact_populate_method :symlink
+  # Force all artifacts to be symlinked
+  artifact_populate_method :symlink
 end
 ~~~
 
@@ -292,25 +292,25 @@ Additional artifacts can be added, in addition to any that the default <code>art
 ~~~ruby
 # in environment/sim.rb
 
-tester = 	OrigenSim::cadence do |sim|
-	# Force all artifacts to be copied
-	artifact_populate_method :copy
-	
-	# Force all artifacts to be symlinked
-	artifact_populate_method :symlink
+tester = OrigenSim::cadence do |sim|
+  # Force all artifacts to be copied
+  artifact_populate_method :copy
+
+  # Force all artifacts to be symlinked
+  artifact_populate_method :symlink
 end
 
 tester.simulator.artifact(:my_artifact) do |a|
-	# Point to a custom target
-	a.target "/path/to/my/artifact.mine"
+  # Point to a custom target
+  a.target "/path/to/my/artifact.mine"
 
-	# Point to a custom run target
-	# Recall this will expand to /path/to/run/dir/custom_artifacts
-	# This ultimately places the artifact at /path/to/run/dir/custom_artifacts/artifact.mine
-	a.run_target "./custom_artifacts"
-	
-	# Indicate this artifact should be copied, regardlesss of global/OS settings.
-	a.populate_method :copy
+  # Point to a custom run target
+  # Recall this will expand to /path/to/run/dir/custom_artifacts
+  # This ultimately places the artifact at /path/to/run/dir/custom_artifacts/artifact.mine
+  a.run_target "./custom_artifacts"
+
+  # Indicate this artifact should be copied, regardlesss of global/OS settings.
+  a.populate_method :copy
 end
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -244,12 +244,18 @@ Warning: Default artifacts only go a single level deep. Directories placed at <c
 will override an entire directory at <code>application/artifacts</code>. If you need more
 control over the artifacts, you can see further down in this guide for manually adding artifacts.
 
-You can customize these directories when instantiating the environment. For example:
+OrigenSim provides two further customizations to the default setup. Like the target directory, you can pass additional
+<code>user_artifact_dirs</code>, which will override any artifacts found at either the default or target artifact levels.
+These artifacts will override each other in the order of the Array definition.
+
+All of these artifacts have different sources, but they are placed in the same <code>artifact_run_dir</code>, which
+defaults to <code>application/artifacts</code>. This location is customizable as well with the <code>artifact_run_dir</code>
+option.
 
 ~~~ruby
 OrigenSim::cadence do |sim|
-  # Change the default artifact directory
-  sim.artifact_dir "#{Origen.app.root}/simulation/testbench"
+  # Add a user artifact directory
+  sim.user_artifact_dirs ["#{Origen.app.root}/simulation/testbench"]
 
   # Change the artifact target location, within the context of the run directory.
   # NOTE: this is relative to the run_dir. This expands to /path/to/run/dir/testbench
@@ -301,17 +307,12 @@ The <code>OrigenSim::Artifacts</code> class inherits from
 [Origen::Componentable](http://origen-sdk.org/origen/guides/models/componentable/#The_Parent_Class),
 so any of the <i>componentable</i> methods are available.
 
-Additional artifacts can be added to any that the default <code>artifact_dir</code> picks up:
+Additional single-artifact items can be added manually:
 
 ~~~ruby
 # in environment/sim.rb
 
 tester = OrigenSim::cadence do |sim|
-  # Force all artifacts to be copied
-  artifact_populate_method :copy
-
-  # Force all artifacts to be symlinked
-  artifact_populate_method :symlink
 end
 
 tester.simulator.artifact(:my_artifact) do |a|

--- a/README.md
+++ b/README.md
@@ -229,18 +229,31 @@ directories that need to be available in the <code>run_dir</code> prior to the s
 reconstruct the run directory regardless of vendor or target configurations, and without requiring you to build in the
 logic into the application itself.
 
-OrigenSim will automatically look for artifacts in the directory <code>#{Origen.app.root}/simulation/_artifacts_</code>.
-Anything in the this folder will be moved to the run directory and placed in <code>_artifacts_</code> just before the
-simulation process starts. You can customize these directories when instantiating the environment. For example:
+OrigenSim will automatically look for artifacts in the directory <code>#{Origen.app.root}/simulation/application/artifacts</code>.
+Anything in the this folder will be moved to the run directory and placed in <code>application/artifacts</code> just before the
+simulation process starts. These artifacts will be populated across targets. You can override an artifact with one
+specific to your target by placing an artifact with the same name in <code>simulation/\<target\>/artifacts</code>. 
+
+For example, if I have an artifact <code>simulation/application/artifacts/startup.sv</code> that I need for 
+three targets, <code>rtl</code>, <code>part_analog</code>, and <code>all_analog</code>, this same artifact will be used
+whenever any of those targets are used. Then, consider I have a new target <code>gate</code>, which has a different
+<code>startup.sv</code> to run. By placing this at <code>simulation/gate/artifacts/startup.sv</code>, OrigenSim
+will replace the artifact in <code>simulation/application/artifacts</code> with this one, in the same <code>run_dir</code>.
+
+Warning: Default artifacts only go a single level deep. Directories placed at <code>simulation/\<target\>/artifacts</code>
+will override an entire directory at <code>application/artifacts</code>. If you need more
+control over the artifacts, you can see further down in this guide for manually adding artifacts.
+
+You can customize these directories when instantiating the environment. For example:
 
 ~~~ruby
 OrigenSim::cadence do |sim|
   # Change the default artifact directory
-  sim.artifact_dir "#{Origen.app.root}/simulation/_testbench_"
+  sim.artifact_dir "#{Origen.app.root}/simulation/testbench"
 
   # Change the artifact target location, within the context of the run directory.
-  # NOTE: this is relative to the run_dir. This expands to /path/to/run/dir/_testbench_
-   sim.artifact_run_dir "./_testbench_"
+  # NOTE: this is relative to the run_dir. This expands to /path/to/run/dir/testbench
+   sim.artifact_run_dir "./testbench"
 end
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -225,12 +225,12 @@ same directory that the compiled snapshot resides in and will most likely break 
 snapshot.
 
 OrigenSim provides an <code>artifacts</code> API to handle this problem. <code>Artifacts</code> are just files or
-directories that need to be available in the <code>run_dir</cdoe> prior to the simulation start. This can be used to
-reconstruct the run directory regardless of vendor or target configurations, and without needing to build in the
-logic to the application itself.
+directories that need to be available in the <code>run_dir</code> prior to the simulation start. This can be used to
+reconstruct the run directory regardless of vendor or target configurations, and without requiring you to build in the
+logic into the application itself.
 
 OrigenSim will automatically look for artifacts in the directory <code>#{Origen.app.root}/simulation/_artifacts_</code>.
-Anything in the this folder will be moved to the run directory and place in <code>_artifacts_</code> just before the
+Anything in the this folder will be moved to the run directory and placed in <code>_artifacts_</code> just before the
 simulation process starts. You can customize these directories when instantiating the environment. For example:
 
 ~~~ruby
@@ -244,12 +244,12 @@ OrigenSim::cadence do |sim|
 end
 ~~~
 
-Note here is that the <code>artifact_run_dir</code> is <u>implicitly relative</u> to the
-<code>run_dir</code>. Relative paths are expanded in the context of the <code>run_dir</code>, <u>not</u> relative to
+Note here that the <code>artifact_run_dir</code> is <b>implicitly relative</b> to the
+<code>run_dir</code>. Relative paths are expanded in the context of the <code>run_dir</code>, <b>not</b> relative to
 the current script location.
 
 Artifacts can be populated either by symlinks or by copying the contents directly. By default, Linux will symlink the
-contents and unlink to clean them. However, due to the elevated priveledges required by Windows to symlink objects,
+contents and unlink to clean them. However, due to the elevated priveledges required by later Windows systems to symlink objects,
 the default behavior for Windows is to just copy files. This does mean that larger, and/or a large number, of artifacts
 may take longer. This behavior can be changed however:
 
@@ -264,9 +264,15 @@ end
 ~~~
 
 OrigemSim's artifacts can be queried, populated, or cleaned, directly by accessing the <code>OrigenSim.artifact</code>
-object (note: the exclusion of the <i>s</i>):
+object (note: the exclusion of the <i>s</i>). Some methods also exist to retrieve and list the current artifacts:
 
 ~~~ruby
+# Populate all the artifacts
+tester.simulator.artifact.populate
+
+# Clean the currently populated artifacts
+tester.simulator.artifact.clean
+
 # List the current artifact names
 tester.simulator.list_artifacts
 
@@ -276,18 +282,13 @@ tester.simulator.artifacts
 # Retrieve a single artifact
 tester.simulator.artifacts[my_artifact]
 tester.simulator.artifact[my_artifact]
-
-# Populate all the artifacts
-tester.simulator.artifact.populate
-
-# Clean the currently populated artifacts
-tester.simulator.artifact.clean
 ~~~
 
-The <code>OrigenSim::Artifacts</code> class inherits from [Origen::Componentable](),
+The <code>OrigenSim::Artifacts</code> class inherits from
+[Origen::Componentable](http://origen-sdk.org/origen/guides/models/componentable/#The_Parent_Class),
 so any of the <i>componentable</i> methods are available.
 
-Additional artifacts can be added, in addition to any that the default <code>artifact_dir</code> picks up, by:
+Additional artifacts can be added to any that the default <code>artifact_dir</code> picks up:
 
 ~~~ruby
 # in environment/sim.rb
@@ -314,7 +315,7 @@ tester.simulator.artifact(:my_artifact) do |a|
 end
 ~~~
 
-Note that this takes place <u>outside</u> of the initial tester instantiation, but can still occur in the environment
+Note that this takes place <b>outside</b> of the initial tester instantiation, but can still occur in the environment
 file.
 
 ### The VPI Extension

--- a/lib/origen_sim/artifacts.rb
+++ b/lib/origen_sim/artifacts.rb
@@ -79,7 +79,7 @@ module OrigenSim
         elsif populate_method == :copy
           FileUtils.cp(target, run_target)
         else
-          Origen.app.fail! "Cannot populate artifact :#{name} with populate method #{pop_method}!"
+          Origen.app.fail! "Cannot populate artifact :#{name} with populate method #{populate_method}!"
         end
       end
 

--- a/lib/origen_sim/artifacts.rb
+++ b/lib/origen_sim/artifacts.rb
@@ -1,0 +1,101 @@
+module OrigenSim
+  module Artifacts
+    class Artifacts
+      include Origen::Componentable
+
+      # Disable accessors on the simulator. Artifact retrieval must use simulator.artifact[name]
+      COMPONENTABLE_ADDS_ACCESSORS = false
+
+      # Clean up the names a bit. Componentable assumes the class name is the singleton name, but we're doing the opposite here.
+      COMPONENTABLE_SINGLETON_NAME = 'artifact'
+      COMPONENTABLE_PLURAL_NAME = 'artifacts'
+
+      def initialize
+        # Don't need the full extent of Origen::Mdoel, so we'll just init the includer class directly.
+        Origen::Componentable.init_includer_class(self)
+      end
+
+      # Force the class to be an OrigenSim::Artifacts::Artifact
+      def add(name, options = {}, &block)
+        instances = _split_by_instances(name, options, &block)
+        return_instances = []
+        instances.each do |n, opts|
+          opts[:class_name] = OrigenSim::Artifacts::Artifact
+          return_instances << _add(n, opts)
+        end
+
+        return_instances.size == 1 ? return_instances.first : return_instances
+      end
+
+      def populate
+        artifacts.each do |name, artifact|
+          Origen.log.info "Populating artifact: #{artifact.target}"
+          Origen.log.info "                 to: #{artifact.run_target}"
+          artifact.populate
+        end
+        true
+      end
+
+      def clean
+        artifacts.each do |name, artifact|
+          Origen.log.info "Cleaning artifact: #{artifact.run_target}"
+          artifact.clean
+        end
+        true
+      end
+    end
+
+    class Artifact
+      attr_reader :name
+      attr_reader :parent
+
+      def initialize(options)
+        @name = options.delete(:name)
+        @parent = options.delete(:parent)
+        @options = options
+      end
+
+      def target
+        Pathname(@options[:target] || parent.artifact_dir)
+      end
+
+      def run_target
+        run_target = Pathname(@options[:run_target] || parent.artifact_run_dir)
+        if run_target.absolute?
+          run_target.join(target.basename)
+        else
+          parent.artifact_run_dir.join(run_target).join(target.basename)
+        end
+      end
+
+      def populate_method
+        @options[:populate_method] || parent.artifact_populate_method
+      end
+      alias_method :pop_method, :populate_method
+
+      def populate
+        if populate_method == :symlink
+          File.symlink(target, run_target)
+        elsif populate_method == :copy
+          FileUtils.cp(target, run_target)
+        else
+          Origen.app.fail! "Cannot populate artifact :#{name} with populate method #{pop_method}!"
+        end
+      end
+
+      def clean
+        if File.exist?(run_target)
+          if File.symlink?(run_target)
+            File.unlink(run_target)
+          else
+            FileUtils.rm_r(run_target)
+          end
+        end
+      end
+
+      def reconfigure(options)
+        @options = options
+      end
+    end
+  end
+end

--- a/lib/origen_sim/simulation.rb
+++ b/lib/origen_sim/simulation.rb
@@ -108,6 +108,13 @@ module OrigenSim
         @heartbeat_thread.stop
       else
         Process.kill('SIGHUP', @heartbeat_pid)
+        
+        # Ensure that the process has stopped before closing the IO pipes
+        begin
+          Process.waitpid(@heartbeat_pid)
+        rescue Errno::ECHILD
+          # Heartbeat process has already stopped, so ignore this.
+        end
       end
     end
 

--- a/lib/origen_sim/simulation.rb
+++ b/lib/origen_sim/simulation.rb
@@ -108,7 +108,7 @@ module OrigenSim
         @heartbeat_thread.stop
       else
         Process.kill('SIGHUP', @heartbeat_pid)
-        
+
         # Ensure that the process has stopped before closing the IO pipes
         begin
           Process.waitpid(@heartbeat_pid)

--- a/lib/origen_sim/simulator.rb
+++ b/lib/origen_sim/simulator.rb
@@ -149,7 +149,7 @@ module OrigenSim
               add_artifact(a.basename.to_s, target: a)
             end
           else
-            Origen.app.fail! "Simulator configuration specified a user artifact dir at #{d} but this directory could not be found!"
+            Origen.app.fail! message: "Simulator configuration specified a user artifact dir at #{d} but this directory could not be found!"
           end
         end
       end

--- a/lib/origen_sim/simulator.rb
+++ b/lib/origen_sim/simulator.rb
@@ -125,16 +125,30 @@ module OrigenSim
       clear_artifacts
 
       # Add any artifacts in the given artifact path
-      artifact_dir.children.each { |a| artifact(a.to_s, target: a) }
+      artifact_dir.children.each { |a| artifact(a.basename.to_s, target: a) }
+      
+      # Add any artifacts from the target-specific path (simulation/<target>/artifacts). Files of the same name
+      # will override artifacts residing in the default directory.
+      if Dir.exists?(target_artifact_dir)
+        target_artifact_dir.children.each do |a|
+          remove_artifact(a.basename.to_s) if has_artifact?(a.basename.to_s)
+          add_artifact(a.basename.to_s, target: a)
+        end
+      end
+      
       self
     end
 
     def artifact_dir
-      Pathname(@configuration[:artifact_dir] || "#{Origen.app.root}/simulation/_artifacts_")
+      Pathname(@configuration[:artifact_dir] || "#{Origen.app.root}/simulation/application/artifacts")
+    end
+    
+    def target_artifact_dir
+      Pathname(@configuration[:target_artifact_dir] || "#{Origen.app.root}/simulation/#{Origen.target.name}/artifacts")
     end
 
     def artifact_run_dir
-      p = Pathname(@configuration[:artifact_run_dir] || './_artifacts_')
+      p = Pathname(@configuration[:artifact_run_dir] || './application/artifacts')
       if p.absolute?
         p
       else


### PR DESCRIPTION
Reinstated <code>artifacts</code> to allow OrigenSim to move files from wherever to the <code>run_dir</code> for us, without regards to vendor or target. 

For my case, <code>artifacts</code> ended up being flash firmware, some default fuse-like values, some basic ROM code, and an analog settings file. The first few are loaded in the testbench during an <code>initial block</code> using <code>readmemh</code>, which had a path relative to the run directory. Previously, these would have to be manually moved and we'd need to know where OrigenSim was planning to run the simulation beforehand. Now, OrigenSim will handle them itself.

The README was updated to show some basic usages. I used [Origen::Componentable](http://origen-sdk.org/origen/guides/models/componentable/) for this, which even though I found some bugs I'll need to fix back in that, they were easy enough to work around to get a release of OrigenSim out. However, expanding <code>artifacts</code> in the future should be very easy, should we need to.