### PR TITLE
Ignore case when matching log lines

### DIFF
--- a/lib/origen_sim/stderr_reader.rb
+++ b/lib/origen_sim/stderr_reader.rb
@@ -14,7 +14,7 @@ module OrigenSim
             if line
               line = line.chomp
               if OrigenSim.fail_on_stderr && !line.empty? &&
-                 !OrigenSim.stderr_string_exceptions.any? { |s| line =~ /#{s}/ }
+                 !OrigenSim.stderr_string_exceptions.any? { |s| line =~ /#{s}/i }
                 # We're failing on stderr, so print its results and log as errors if its not an exception.
                 @logged_errors = true
                 Origen.log.error "(STDERR): #{line}"

--- a/lib/origen_sim/stderr_reader.rb
+++ b/lib/origen_sim/stderr_reader.rb
@@ -14,7 +14,7 @@ module OrigenSim
             if line
               line = line.chomp
               if OrigenSim.fail_on_stderr && !line.empty? &&
-                 !OrigenSim.stderr_string_exceptions.any? { |s| line =~ /#{s}/i }
+                 !OrigenSim.stderr_string_exceptions.any? { |s| s.is_a?(Regexp) ? s.match?(line) : line =~ /#{s}/i }
                 # We're failing on stderr, so print its results and log as errors if its not an exception.
                 @logged_errors = true
                 Origen.log.error "(STDERR): #{line}"

--- a/lib/origen_sim/stdout_reader.rb
+++ b/lib/origen_sim/stdout_reader.rb
@@ -13,16 +13,16 @@ module OrigenSim
             line = @socket.gets
             if line
               line = line.chomp
-              if OrigenSim.error_strings.any? { |s| line =~ /#{s}/i } &&
-                 !OrigenSim.error_string_exceptions.any? { |s| line =~ /#{s}/i }
+              if OrigenSim.error_strings.any? { |s| s.is_a?(Regexp) ? s.match?(line) : line =~ /#{s}/i } &&
+                 !OrigenSim.error_string_exceptions.any? { |s| s.is_a?(Regexp) ? s.match?(line) : line =~ /#{s}/i }
                 @logged_errors = true
                 Origen.log.error "(STDOUT): #{line}"
-              elsif OrigenSim.warning_strings.any? { |s| line =~ /#{s}/i } &&
-                    !OrigenSim.warning_string_exceptions.any? { |s| line =~ /#{s}/i }
+              elsif OrigenSim.warning_strings.any? { |s| s.is_a?(Regexp) ? s.match?(line) : line =~ /#{s}/i } &&
+                    !OrigenSim.warning_string_exceptions.any? { |s| s.is_a?(Regexp) ? s.match?(line) : line =~ /#{s}/i }
                 Origen.log.warn line
               else
                 if OrigenSim.verbose? ||
-                   OrigenSim.log_strings.any? { |s| line =~ /#{s}/i }
+                   OrigenSim.log_strings.any? { |s| s.is_a?(Regexp) ? s.match?(line) : line =~ /#{s}/i }
                   Origen.log.info line
                 else
                   Origen.log.debug line

--- a/lib/origen_sim/stdout_reader.rb
+++ b/lib/origen_sim/stdout_reader.rb
@@ -13,16 +13,16 @@ module OrigenSim
             line = @socket.gets
             if line
               line = line.chomp
-              if OrigenSim.error_strings.any? { |s| line =~ /#{s}/ } &&
-                 !OrigenSim.error_string_exceptions.any? { |s| line =~ /#{s}/ }
+              if OrigenSim.error_strings.any? { |s| line =~ /#{s}/i } &&
+                 !OrigenSim.error_string_exceptions.any? { |s| line =~ /#{s}/i }
                 @logged_errors = true
                 Origen.log.error "(STDOUT): #{line}"
-              elsif OrigenSim.warning_strings.any? { |s| line =~ /#{s}/ } &&
-                    !OrigenSim.warning_string_exceptions.any? { |s| line =~ /#{s}/ }
+              elsif OrigenSim.warning_strings.any? { |s| line =~ /#{s}/i } &&
+                    !OrigenSim.warning_string_exceptions.any? { |s| line =~ /#{s}/i }
                 Origen.log.warn line
               else
                 if OrigenSim.verbose? ||
-                   OrigenSim.log_strings.any? { |s| line =~ /#{s}/ }
+                   OrigenSim.log_strings.any? { |s| line =~ /#{s}/i }
                   Origen.log.info line
                 else
                   Origen.log.debug line

--- a/templates/origen_guides/simulation/log.md.erb
+++ b/templates/origen_guides/simulation/log.md.erb
@@ -30,11 +30,18 @@ In such a case you can add strings to the `stderr_string_exceptions` array and a
 the given text will by ignored:
 
 ~~~ruby
-OrigenSim.stderr_string_exceptions << 'invalid adc config'
+OrigenSim.stderr_string_exceptions << 'invalid adc config'    # Case in-sensitive match
 ~~~
 
 **Note that in all of these cases the given text is considered to be case-insensitive when considering if
 it matches a log line.**
+
+If you need case-sensitivity (or more generally need more control of exactly what is considered to be a match), you can
+supply a regular expression instead of a string for all of the cases discussed here:
+
+~~~ruby
+OrigenSim.stderr_string_exceptions << /invalid adc config/    # Case sensitive match
+~~~
 
 Similarly, if you find that the default of matching for _ERROR_ in STDOUT messages is being overly aggressive,
 exceptions can be added in a similar way:

--- a/templates/origen_guides/simulation/log.md.erb
+++ b/templates/origen_guides/simulation/log.md.erb
@@ -4,7 +4,7 @@ Log output from simulations is often very verbose, which can make it hard to dis
 that are important and those that can be safely ignored.
 
 By default, OrigenSim will automatically suppress all simulator log output except for any lines that
-contain the text _WARNING_ or _ERROR_; both of these will be logged to the console and any occurrences of
+contain the text _WARNING_ or _ERROR_ (case insensitive); both of these will be logged to the console and any occurrences of
 the latter will also make the result of the simulation be classed as a FAIL.
 
 All log output can be shown in the console by running with the `-d` or `--debug` switches, and the log files will
@@ -32,6 +32,9 @@ the given text will by ignored:
 ~~~ruby
 OrigenSim.stderr_string_exceptions << 'invalid adc config'
 ~~~
+
+**Note that in all of these cases the given text is considered to be case-insensitive when considering if
+it matches a log line.**
 
 Similarly, if you find that the default of matching for _ERROR_ in STDOUT messages is being overly aggressive,
 exceptions can be added in a similar way:


### PR DESCRIPTION
When [writing up the log guide](http://origen-sdk.org/origen/guides/simulation/log/) I thought that it might be safer to do these matches case insensitive.

Thoughts?