### PR TITLE
Multi-line comments and other general improvements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    origen_sim (0.12.1)
+    origen_sim (0.12.2)
       origen (>= 0.35.0)
       origen_testers
       origen_verilog (>= 0.5)

--- a/config/shared_commands.rb
+++ b/config/shared_commands.rb
@@ -11,6 +11,13 @@ when 'generate'
 
   @application_options << ["--flow NAME", "Simulate multiple patterns back-back within a single simulation with the given name", ->(options, name) { OrigenSim.flow = name }]
 
+  @application_options << ["--socket_dir PATH", "Specify the directory to be used for creating the Origen -> simulator communication socket (/tmp by default) ", ->(options, path) {
+    FileUtils.mkdir_p(path) unless File.exist?(path)
+    path = Pathname.new(path)
+    path = path.realpath.to_s
+    OrigenSim.socket_dir = path
+  }]
+
 when "sim:ci", "origen_sim:ci"
   require "#{Origen.root!}/lib/origen_sim/commands/ci"
   exit 0

--- a/config/version.rb
+++ b/config/version.rb
@@ -1,7 +1,7 @@
 module OrigenSim
   MAJOR = 0
   MINOR = 12
-  BUGFIX = 1
+  BUGFIX = 2
   DEV = nil
 
   VERSION = [MAJOR, MINOR, BUGFIX].join(".") + (DEV ? ".pre#{DEV}" : '')

--- a/ext/bridge.c
+++ b/ext/bridge.c
@@ -538,6 +538,7 @@ PLI_INT32 bridge_wait_for_msg(p_cb_data data) {
   UNUSED(data);
   int max_msg_len = 1024;
   char msg[max_msg_len];
+  char comment[128];
   int err;
   char *opcode, *arg1, *arg2, *arg3, *arg4;
   vpiHandle handle;
@@ -706,13 +707,18 @@ PLI_INT32 bridge_wait_for_msg(p_cb_data data) {
         }
         break;
       // Set Comment
-      //   c^Some comment about the pattern
+      //   c^0^Some comment about the pattern
       case 'c' :
-        handle = vpi_handle_by_name(ORIGEN_SIM_TESTBENCH_CAT("debug.comments"), NULL);
         arg1 = strtok(NULL, "^");
+        arg2 = strtok(NULL, "^");
+
+        strcpy(comment, ORIGEN_SIM_TESTBENCH_CAT("debug.comments"));
+        strcat(comment, arg1);
+
+        handle = vpi_handle_by_name(comment, NULL);
 
         v.format = vpiStringVal;
-        v.value.str = arg1;
+        v.value.str = arg2;
         vpi_put_value(handle, &v, NULL, vpiNoDelay);
         break;
       // Log all messages

--- a/lib/origen_sim.rb
+++ b/lib/origen_sim.rb
@@ -6,6 +6,8 @@ require 'origen_sim/origen/pins/pin'
 require 'origen_sim/origen/top_level'
 require 'origen_sim/origen/application/runner'
 module OrigenSim
+  NUMBER_OF_COMMENT_LINES = 10
+
   # THIS FILE SHOULD ONLY BE USED TO LOAD RUNTIME DEPENDENCIES
   # If this plugin has any development dependencies (e.g. dummy DUT or other models that are only used
   # for testing), then these should be loaded from config/boot.rb

--- a/lib/origen_sim.rb
+++ b/lib/origen_sim.rb
@@ -60,6 +60,14 @@ module OrigenSim
     @flow
   end
 
+  def self.socket_dir=(val)
+    @socket_dir = val
+  end
+
+  def self.socket_dir
+    @socket_dir
+  end
+
   def self.error_strings
     @error_strings ||= ['ERROR']
   end

--- a/lib/origen_sim/heartbeat.rb
+++ b/lib/origen_sim/heartbeat.rb
@@ -14,7 +14,13 @@ module OrigenSim
       @continue = true
       super do
         while @continue
-          socket.write("OK\n")
+          begin
+            socket.write("OK\n")
+          rescue Errno::EPIPE => e
+            Origen.log.error 'Communication with the simulation monitor has been lost!'
+            sleep 2
+            exit 1
+          end
           sleep 5
         end
       end

--- a/lib/origen_sim/simulation.rb
+++ b/lib/origen_sim/simulation.rb
@@ -200,10 +200,12 @@ module OrigenSim
       @socket.close
       @stderr.close
       @stdout.close
+      @status.close
       File.unlink(socket_id(:heartbeat)) if File.exist?(socket_id(:heartbeat))
       File.unlink(socket_id) if File.exist?(socket_id)
       File.unlink(socket_id(:stderr)) if File.exist?(socket_id(:stderr))
       File.unlink(socket_id(:stdout)) if File.exist?(socket_id(:stdout))
+      File.unlink(socket_id(:status)) if File.exist?(socket_id(:status))
     end
 
     # Returns true if the simulation is running
@@ -230,7 +232,7 @@ module OrigenSim
     end
 
     def socket_id(type = nil)
-      @socket_ids[type] ||= "/tmp/#{socket_number}#{type}.sock"
+      @socket_ids[type] ||= "#{OrigenSim.socket_dir || '/tmp'}/#{socket_number}#{type}.sock"
     end
 
     private

--- a/lib/origen_sim/simulation.rb
+++ b/lib/origen_sim/simulation.rb
@@ -96,7 +96,17 @@ module OrigenSim
       else
         @heartbeat_pid = fork do
           loop do
-            @heartbeat.write("OK\n")
+            begin
+              @heartbeat.write("OK\n")
+            rescue Errno::EPIPE => e
+              if monitor_running?
+                Origen.log.error 'Communication with the simulation monitor has been lost (though it seems to still be running)!'
+              else
+                Origen.log.error 'The simulation monitor has stopped unexpectedly!'
+              end
+              sleep 2 # To make sure that any log output from the simulator is captured before we pull the plug
+              exit 1
+            end
             sleep 5
           end
         end
@@ -119,7 +129,8 @@ module OrigenSim
     end
 
     # Open the communication channels with the simulator
-    def open(timeout)
+    def open(monitor_pid, timeout)
+      @monitor_pid = monitor_pid
       timeout_connection(timeout) do
         start_heartbeat
         @stdout = @server_stdout.accept
@@ -200,6 +211,18 @@ module OrigenSim
       return false unless pid
       begin
         Process.getpgid(pid)
+        true
+      rescue Errno::ESRCH
+        false
+      end
+    end
+
+    # Returns true if the simulation monitor process (the one that receives the heartbeat
+    # and kills the simulation if it stops) is running
+    def monitor_running?
+      return false unless @monitor_pid
+      begin
+        Process.getpgid(@monitor_pid)
         true
       rescue Errno::ESRCH
         false

--- a/lib/origen_sim/simulator.rb
+++ b/lib/origen_sim/simulator.rb
@@ -533,10 +533,10 @@ module OrigenSim
 
       Origen.log.debug 'Starting the simulation monitor...'
 
-      simulator_parent_process = spawn("ruby -e \"#{launch_simulator}\"")
-      Process.detach(simulator_parent_process)
+      monitor_pid = spawn("ruby -e \"#{launch_simulator}\"")
+      Process.detach(monitor_pid)
 
-      simulation.open(config[:startup_timeout] || 60) # This will block until the simulation process has started
+      simulation.open(monitor_pid, config[:startup_timeout] || 60) # This will block until the simulation process has started
 
       # The VPI extension will send 'READY!' when it starts, make sure we get it before proceeding
       data = get
@@ -559,6 +559,14 @@ module OrigenSim
     # Send the given message string to the simulator
     def put(msg)
       simulation.socket.write(msg + "\n")
+    rescue Errno::EPIPE => e
+      if simulation.running?
+        Origen.log.error 'Communication with the simulator has been lost (though it seems to still be running)!'
+      else
+        Origen.log.error 'The simulator has stopped unexpectedly!'
+      end
+      sleep 2 # To make sure that any log output from the simulator is captured before we pull the plug
+      exit 1
     end
 
     # Get a message from the simulator, will block until one
@@ -623,11 +631,16 @@ module OrigenSim
       end
     end
 
-    def write_comment(comment)
+    def write_comment(line, comment)
+      return if line >= OrigenSim::NUMBER_OF_COMMENT_LINES
       # Not sure what the limiting factor here is, the comment memory in the test bench should
       # be able to handle 1024 / 8 length strings, but any bigger than this hangs the simulation
-      comment = comment[0..96]
-      put("c^#{comment}")
+      comment = comment ? comment[0..96] : ''
+      if dut_version > '0.12.1'
+        put("c^#{line}^#{comment} ")  # Space at the end is important so that an empty comment is communicated properly
+      else
+        put("c^#{comment} ")
+      end
     end
 
     # Applies the current state of all pins to the simulation
@@ -714,7 +727,7 @@ module OrigenSim
     # Flush any buffered simulation output, this should cause live wave viewers to
     # reflect the latest state
     def flush
-      if dut_version > '0.12.1'
+      if dut_version > '0.12.0'
         put('j^')
         sync_up
       else

--- a/pattern/test.rb
+++ b/pattern/test.rb
@@ -11,6 +11,9 @@ Pattern.create do
   dut.jtag.read_ir(0xE, size: 4)
 
   ss "Switch to slower timeset"
+  ss "And test multiple comments for Github issue #8"
+  ss "Blah blah, more stuff to verify that we can handle large comment blocks without having problems"
+  ss "Blah blah, more stuff to verify that we can handle large comment blocks without having problems"
   tester.set_timeset("func", 200)
 
   dut.jtag.write_ir(0x5, size: 4)

--- a/templates/empty.gtkw
+++ b/templates/empty.gtkw
@@ -17,10 +17,28 @@
 [signals_width] 158
 [sst_expanded] 1
 [sst_vpaned_height] 337
+@800200
+-debug
 @820
 origen.debug.pattern[1023:0]
-origen.debug.comments[1023:0]
+@800200
+-Comments
+@820
+origen.debug.comments0[1023:0]
+origen.debug.comments1[1023:0]
+origen.debug.comments2[1023:0]
+origen.debug.comments3[1023:0]
+origen.debug.comments4[1023:0]
+origen.debug.comments5[1023:0]
+origen.debug.comments6[1023:0]
+origen.debug.comments7[1023:0]
+origen.debug.comments8[1023:0]
+origen.debug.comments9[1023:0]
+@1000200
+-Comments
 @22
 origen.debug.errors[31:0]
+@1000200
+-debug
 [pattern_trace] 1
 [pattern_trace] 0

--- a/templates/empty.svcf
+++ b/templates/empty.svcf
@@ -2,18 +2,22 @@
 # Preferences
 #
 preferences set plugin-enable-svdatabrowser-new 1
-preferences set toolbar-SimControl-WaveWindow {
+preferences set toolbar-Standard-WaveWindow {
   usual
-  position -row 1 -pos 4 -anchor e
+  position -pos 1
 }
 preferences set plugin-enable-groupscope 0
-preferences set sb-display-values 1
 preferences set plugin-enable-interleaveandcompare 0
 preferences set plugin-enable-waveformfrequencyplot 0
 preferences set toolbar-WaveZoom-WaveWindow {
   usual
   position -row 1 -pos 3 -anchor w
 }
+preferences set toolbar-SimControl-WaveWindow {
+  usual
+  position -row 1 -pos 4 -anchor e
+}
+preferences set sb-display-values 1
 preferences set whats-new-dont-show-at-startup 1
 #
 # Groups
@@ -21,6 +25,7 @@ preferences set whats-new-dont-show-at-startup 1
 catch {group new -name Debug -overlay 0}
 catch {group new -name {Group 2} -overlay 0}
 catch {group new -name DUT -overlay 0}
+catch {group new -name Comments -overlay 0}
 group using Debug
 group set -overlay 0
 group set -comment {}
@@ -28,8 +33,7 @@ group clear 0 end
 
 group insert \
     [subst  {[format {origen.debug.pattern[1023:0]}]} ] \
-    [subst  {[format {origen.debug.comments[1023:0]}]} ] \
-    [subst  {[format {origen.debug.errors[31:0]}]} ]
+    Comments
 group using {Group 2}
 group set -overlay 0
 group set -comment {}
@@ -40,6 +44,22 @@ group set -overlay 0
 group set -comment {}
 group clear 0 end
 
+group using Comments
+group set -overlay 0
+group set -comment {}
+group clear 0 end
+
+group insert \
+    [subst  {[format {origen.debug.comments0[1023:0]}]} ] \
+    [subst  {[format {origen.debug.comments1[1023:0]}]} ] \
+    [subst  {[format {origen.debug.comments2[1023:0]}]} ] \
+    [subst  {[format {origen.debug.comments3[1023:0]}]} ] \
+    [subst  {[format {origen.debug.comments4[1023:0]}]} ] \
+    [subst  {[format {origen.debug.comments5[1023:0]}]} ] \
+    [subst  {[format {origen.debug.comments6[1023:0]}]} ] \
+    [subst  {[format {origen.debug.comments7[1023:0]}]} ] \
+    [subst  {[format {origen.debug.comments8[1023:0]}]} ] \
+    [subst  {[format {origen.debug.comments9[1023:0]}]} ]
 
 #
 # Mnemonic Maps
@@ -70,15 +90,51 @@ waveform baseline set -time 0
 
 
 set groupId0 [waveform add -groups Debug]
+
+set groupId1 [waveform find -name Comments]
+set gpGlist1 [waveform hierarchy contents $groupId1]
+set gpID1 [lindex $gpGlist1 0]
+foreach {name attrs} [subst  {
+    {[format {origen.debug.comments0[1023:0]}]} {-radix %a}
+    {[format {origen.debug.comments1[1023:0]}]} {-radix %a}
+    {[format {origen.debug.comments2[1023:0]}]} {-radix %a}
+    {[format {origen.debug.comments3[1023:0]}]} {-radix %a}
+    {[format {origen.debug.comments4[1023:0]}]} {-radix %a}
+    {[format {origen.debug.comments5[1023:0]}]} {-radix %a}
+    {[format {origen.debug.comments6[1023:0]}]} {-radix %a}
+    {[format {origen.debug.comments7[1023:0]}]} {-radix %a}
+    {[format {origen.debug.comments8[1023:0]}]} {-radix %a}
+    {[format {origen.debug.comments9[1023:0]}]} {-radix %a}
+}] childcmds {
+    {}
+    {}
+    {}
+    {}
+    {}
+    {}
+    {}
+    {}
+    {}
+    {}
+} {
+    set expected [ join [waveform signals -format path $gpID1] ]
+    if {[string equal $name $expected] || $name == "cdivider"} {
+        if {$attrs != ""} {
+            eval waveform format $gpID1 $attrs
+        }
+        if { $childcmds != ""} {
+            eval $childcmds
+        }
+    }
+    set gpGlist1 [lrange $gpGlist1 1 end]
+    set gpID1 [lindex $gpGlist1 0]
+}
+
 set gpGlist0 [waveform hierarchy contents $groupId0]
 set gpID0 [lindex $gpGlist0 0]
 foreach {name attrs} [subst  {
     {[format {origen.debug.pattern[1023:0]}]} {-radix %a}
-    {[format {origen.debug.comments[1023:0]}]} {-radix %a}
-    {[format {origen.debug.errors[31:0]}]} {}
 }] childcmds {
-    {}
-    {}
     {}
 } {
     set expected [ join [waveform signals -format path $gpID0] ]
@@ -94,7 +150,21 @@ foreach {name attrs} [subst  {
     set gpID0 [lindex $gpGlist0 0]
 }
 
+set id [waveform add -signals [subst  {
+	{[format {origen.debug.errors[31:0]}]}
+	} ]]
 
 set groupId0 [waveform add -groups DUT]
 
+waveform xview limits 0 32768000ns
+
+#
+# Waveform Window Links
+#
+
+#
+# Console windows
+#
+console set -windowname Console
+window geometry Console 600x250+2364+0
 

--- a/templates/empty.tcl
+++ b/templates/empty.tcl
@@ -7,8 +7,8 @@
 # 	TopLevel.1
 # 	TopLevel.2
 #   Source.1: origen.dut
-#   Wave.1: 3 signals
-#   Group count = 2
+#   Wave.1: 12 signals
+#   Group count = 3
 #   Group Debug signal count = 3
 #   Group DUT signal count = 0
 # End_DVE_Session_Save_Info
@@ -69,7 +69,7 @@ if {![gui_exist_window -window TopLevel.1]} {
 } else { 
     set TopLevel.1 TopLevel.1
 }
-gui_show_window -window ${TopLevel.1} -show_state normal -rect {{525 653} {2223 1819}}
+gui_show_window -window ${TopLevel.1} -show_state normal -rect {{529 678} {2226 1843}}
 
 # ToolBar settings
 gui_set_toolbar_attributes -toolbar {TimeOperations} -dock_state top
@@ -149,7 +149,7 @@ if {![gui_exist_window -window TopLevel.2]} {
 } else { 
     set TopLevel.2 TopLevel.2
 }
-gui_show_window -window ${TopLevel.2} -show_state normal -rect {{293 121} {2365 1172}}
+gui_show_window -window ${TopLevel.2} -show_state normal -rect {{297 146} {2368 1196}}
 
 # ToolBar settings
 gui_set_toolbar_attributes -toolbar {TimeOperations} -dock_state top
@@ -241,15 +241,42 @@ set _session_group_1 Debug
 gui_sg_create "$_session_group_1"
 set Debug "$_session_group_1"
 
-gui_sg_addsignal -group "$_session_group_1" { origen.debug.pattern origen.debug.comments origen.debug.errors }
+gui_sg_addsignal -group "$_session_group_1" { origen.debug.pattern origen.debug.errors }
 gui_set_radix -radix {ascii} -signals {V1:origen.debug.pattern}
 gui_set_radix -radix {unsigned} -signals {V1:origen.debug.pattern}
-gui_set_radix -radix {ascii} -signals {V1:origen.debug.comments}
-gui_set_radix -radix {unsigned} -signals {V1:origen.debug.comments}
 
-set _session_group_2 DUT
+set _session_group_2 $_session_group_1|
+append _session_group_2 Comments
 gui_sg_create "$_session_group_2"
-set DUT "$_session_group_2"
+set Debug|Comments "$_session_group_2"
+
+gui_sg_addsignal -group "$_session_group_2" { origen.debug.comments0 origen.debug.comments1 origen.debug.comments2 origen.debug.comments3 origen.debug.comments4 origen.debug.comments5 origen.debug.comments6 origen.debug.comments7 origen.debug.comments8 origen.debug.comments9 }
+gui_set_radix -radix {ascii} -signals {V1:origen.debug.comments0}
+gui_set_radix -radix {unsigned} -signals {V1:origen.debug.comments0}
+gui_set_radix -radix {ascii} -signals {V1:origen.debug.comments1}
+gui_set_radix -radix {unsigned} -signals {V1:origen.debug.comments1}
+gui_set_radix -radix {ascii} -signals {V1:origen.debug.comments2}
+gui_set_radix -radix {unsigned} -signals {V1:origen.debug.comments2}
+gui_set_radix -radix {ascii} -signals {V1:origen.debug.comments3}
+gui_set_radix -radix {unsigned} -signals {V1:origen.debug.comments3}
+gui_set_radix -radix {ascii} -signals {V1:origen.debug.comments4}
+gui_set_radix -radix {unsigned} -signals {V1:origen.debug.comments4}
+gui_set_radix -radix {ascii} -signals {V1:origen.debug.comments5}
+gui_set_radix -radix {unsigned} -signals {V1:origen.debug.comments5}
+gui_set_radix -radix {ascii} -signals {V1:origen.debug.comments6}
+gui_set_radix -radix {unsigned} -signals {V1:origen.debug.comments6}
+gui_set_radix -radix {ascii} -signals {V1:origen.debug.comments7}
+gui_set_radix -radix {unsigned} -signals {V1:origen.debug.comments7}
+gui_set_radix -radix {ascii} -signals {V1:origen.debug.comments8}
+gui_set_radix -radix {unsigned} -signals {V1:origen.debug.comments8}
+gui_set_radix -radix {ascii} -signals {V1:origen.debug.comments9}
+gui_set_radix -radix {unsigned} -signals {V1:origen.debug.comments9}
+
+gui_sg_move "$_session_group_2" -after "$_session_group_1" -pos 1 
+
+set _session_group_3 DUT
+gui_sg_create "$_session_group_3"
+set DUT "$_session_group_3"
 
 
 # Global: Highlighting
@@ -317,6 +344,7 @@ gui_list_create_group_when_add -wave -disable
 gui_marker_set_ref -id ${Wave.1}  C1
 gui_wv_zoom_timerange -id ${Wave.1} 0 353973502
 gui_list_add_group -id ${Wave.1} -after {New Group} {Debug}
+gui_list_add_group -id ${Wave.1}  -after {origen.debug.pattern[1023:0]} {Debug|Comments}
 gui_list_add_group -id ${Wave.1} -after {New Group} {DUT}
 gui_seek_criteria -id ${Wave.1} {Any Edge}
 

--- a/templates/origen_guides/simulation/patterns.md.erb
+++ b/templates/origen_guides/simulation/patterns.md.erb
@@ -39,6 +39,8 @@ cc "Wait for the program command to complete"
 tester.sim_delay :program_command do
   dut.pin(:done).assert!(1)
 end
+dut.pin(:done).dont_care  # Any pin assertions/reads created within the block will persist beyond it, so
+                          # remember to clear any assertions that you don't want to carryover afterwards
 ~~~
 
 The `sim_delay` method provides the convenience of a match loop for the purposes of
@@ -69,6 +71,8 @@ of time options are supported):
 tester.sim_delay :program_command, padding: { time_in_cycles: 10 } do
   dut.pin(:done).assert!(1)
 end
+dut.pin(:done).dont_care  # Any pin assertions/reads created within the block will persist beyond it, so
+                          # remember to clear any assertions that you don't want to carryover afterwards
 ~~~
 
 By default, the block will be evaluated constantly until it passes when calculating the delay from
@@ -82,6 +86,8 @@ by supplying a `:resolution` option, either as a number of cycles:
 tester.sim_delay :program_command, resolution: 10 do
   dut.pin(:done).assert!(1)
 end
+dut.pin(:done).dont_care  # Any pin assertions/reads created within the block will persist beyond it, so
+                          # remember to clear any assertions that you don't want to carryover afterwards
 ~~~
 
 or by supplying a hash filled with the usual time options:
@@ -90,6 +96,8 @@ or by supplying a hash filled with the usual time options:
 tester.sim_delay :program_command, resolution: { time_in_ns: 50 } do
   dut.pin(:done).assert!(1)
 end
+dut.pin(:done).dont_care  # Any pin assertions/reads created within the block will persist beyond it, so
+                          # remember to clear any assertions that you don't want to carryover afterwards
 ~~~
 
 #### Capturing Responses from the Simulation

--- a/templates/rtl_v/origen.v.erb
+++ b/templates/rtl_v/origen.v.erb
@@ -106,7 +106,9 @@ module debug(errors);
   input [31:0] errors;
 
   reg [1023:0] pattern = 0;
-  reg [1023:0] comments = 0;
+% OrigenSim::NUMBER_OF_COMMENT_LINES.times do |i|
+  reg [1023:0] comments<%= i %> = 'h20;  // Contain a space by default
+% end
 
   reg handshake;
 


### PR DESCRIPTION
This PR adds the following:

* Support for multi-line comments per issue #8 
* Improves error messages in crashed simulation runs rather than falling back to the 'broken pipe' error. 
* Adds the ability to override the socket directory at runtime (a system debug feature rather than a user feature)
* Improves documentation per issue #23 

More details:

Adding support for multiple comments at a given stage proved to be more difficult than simply concatenating them together - this approach quickly ran into issues with exceeding the size allocation of messages and the VPI structs used to set the comment register.
This then drove me down a different path than originally envisaged and instead of simply concatenating multiple comment lines together, they are now captured by multiple comment line registers in the simulation, here is an example from a test case:

![image](https://user-images.githubusercontent.com/158364/45805948-bc5c4200-bcb7-11e8-8efd-8250f02fd9e0.png)

Overall, I think this makes for a more user-friendly solution, it is much more readable than simply extending a single comment line/variable.
I've chosen 10 lines as an arbitrary number which seems to strike the right balance between providing enough information while not taking up too much in terms of screen real estate. Any additional lines will be discarded, so you will always see the first 10 and additional messages will not overwrite like they did before.

All of the starter wave configuration files have been updated to put all 10 registers into a group called `Comments` within the existing `debug` group.

@coreyeng, I've added a few things that might help with debug of your LSF issues. Instead of just saying broken pipe it will now try and differentiate between communication going down because the socket is broken (and the simulator process is still running), or because the simulator process has stopped.

I also added a sleep for 2 seconds before exiting in the event of communications going down, this was just to keep the stdout/stderr loggers alive a bit longer in case the simulator had any last words that we were missing by exiting immediately.

Finally I added the ability to specify a different socket directory at runtime instead of `/tmp`, which is the default.
So you could do:  `origen g my_pattern --socket_dir tmp/sockets` to use the tmp dir in the application instead. This may or may not do much, but it will at least allow you to rule out whether the problem is due to the use of `/tmp` or not.

@priyavadan, when I sat down to implement the changes discussed in #23 I came to the conclusion that the current behavior is the correct one and that this was more of a documentation issue.

I've updated the example with the done pin in the guides to show it being set to dont care afterwards.

The reason for not adding the auto-rollback is that it would introduce an inconsistency between `sim_delay` and how Origen works in general (i.e. pin states normally persist), and with match loop blocks which don't do a similar auto-rollback. Also I think in many application cases continuing to enforce the assertion established by the delay block would be the desired behavior.

So, I've left this up to the application and improved the docs to hopefully avoid others getting caught out like you were.



