### PR TITLE
Prevent sim monitor stopped errors during legal shutdown

### DIFF
--- a/lib/origen_sim/simulator.rb
+++ b/lib/origen_sim/simulator.rb
@@ -869,6 +869,8 @@ module OrigenSim
       @simulation_open = false
       simulation.error_count = error_count
       Origen.listeners_for(:simulation_shutdown).each(&:simulation_shutdown)
+      sync_up
+      simulation.ended = true
       end_simulation
       # Give the simulator time to shut down
       sleep 0.1 while simulation.running?


### PR DESCRIPTION
Under some conditions simulations would pass but would show the following error in the log near the end:

~~~
[ERROR]    1234.567[0.000] || The simulation monitor has stopped unexpectedly!
~~~

This appears to be caused by the simulation monitor ([this process](https://github.com/Origen-SDK/origen_sim/blob/master/lib/origen_sim/simulator.rb#L475)) aborting in an un-controlled manner once the simulation has completed and been told to stop.

While the exact sequence of events to cause this is not understood, this patch will inhibit the error message being written if it occurs after the simulation has completed successfully and been told to stop.

Note that there are effectively two parallel implementations of this fix since OrigenSim currently works around the fact that the byebug debugger does not keep parallel threads running asynchronously at a breakpoint, and a forked process is used instead.
Communicating with such a forked process is tricky and achieved here by writing a temporary file to let it know that the simulation has finished and it should not display this meaningless error.



