### PR TITLE
Bug fixes

### DIFF
--- a/ext/bridge.c
+++ b/ext/bridge.c
@@ -1084,10 +1084,12 @@ PLI_INT32 bridge_on_miscompare(PLI_BYTE8 * user_dat) {
 
     vpi_free_object(argv);
 
-    if (received) {
+    if (received == 1 || received == 0) {
       origen_log(LOG_ERROR, "Miscompare on pin %s, expected %d received %d", pin_name, expected, received);
+    } else if (received == -2) {
+      origen_log(LOG_ERROR, "Miscompare on pin %s, expected %d received Z", pin_name, expected);
     } else {
-      origen_log(LOG_ERROR, "Miscompare on pin %s, expected %d received X or Z", pin_name, expected);
+      origen_log(LOG_ERROR, "Miscompare on pin %s, expected %d received X", pin_name, expected);
     }
 
     error_count++;
@@ -1116,11 +1118,7 @@ PLI_INT32 bridge_on_miscompare(PLI_BYTE8 * user_dat) {
         strcpy((*miscompare).pin_name, pin_name);
         (*miscompare).cycle = cycle_count;
         (*miscompare).expected = expected;
-        if (received) {
-          (*miscompare).received = received;
-        } else {
-          (*miscompare).received = -1;
-        }
+        (*miscompare).received = received;
       }
       transaction_error_count++;
     }

--- a/lib/origen_sim/stdout_reader.rb
+++ b/lib/origen_sim/stdout_reader.rb
@@ -10,27 +10,25 @@ module OrigenSim
       @last_message_at = Time.now
       super do
         begin
-          line = ''
+          line = nil
           while @continue
             loop do
               out = @socket.gets
-              if out.nil?
-                line += ''
-                break
-              end
+              break if out.nil?
 
-              unless line.empty?
+              unless !line || line.empty?
                 # If there's already stuff in the current line,
                 # remove the VPI cruft and leave just the remainder of the message.
                 out = out.split(' ', 2)[-1]
               end
 
+              line ||= ''
               if out.chomp.end_with?(OrigenSim::Simulator::MULTIPART_LOGGER_TOKEN)
                 # Part of a multipart message. Add this to the current line
                 # and grab the next piece.
                 line += out.chomp.gsub(OrigenSim::Simulator::MULTIPART_LOGGER_TOKEN, '')
               else
-                # Either a single message or a the end of a multi-part message.
+                # Either a single message or the end of a multi-part message.
                 # Add this to the line break to print the output to the console.
                 line += out
                 break
@@ -71,7 +69,7 @@ module OrigenSim
                   end
                 end
               end
-              line = ''
+              line = nil
               @last_message_at = Time.now
             end
           end

--- a/lib/origen_sim/tester.rb
+++ b/lib/origen_sim/tester.rb
@@ -328,7 +328,7 @@ module OrigenSim
                 end
 
                 diffs.each do |position, received, expected|
-                  if received == -1
+                  if received == -1 || received == -2
                     reg_or_val[position].unknown = true
                   else
                     reg_or_val[position].data = received
@@ -377,7 +377,7 @@ module OrigenSim
             if actual_data_available
               actual = reg_or_val
               diffs.each do |position, received, expected|
-                if received == -1
+                if received == -1 || received == -2
                   actual = '?' * reg_or_val.to_s(16).size
                   break
                 elsif received == 1

--- a/pattern/fails.rb
+++ b/pattern/fails.rb
@@ -1,0 +1,19 @@
+# This pattern is expected to fail, use it to visually inspect that OrigenSim's
+# error reporting is working
+Pattern.create do
+  ss "Test a register-level miscompare"
+  dut.cmd.write!(0x1234_5678)
+  dut.cmd.read!(0x1233_5678)
+
+  ss "Test a bit-level miscompare, expect 1"
+  dut.ana_test.write!(0)
+  dut.ana_test.bgap_out.read!(1)
+  ss "Test a bit-level miscompare, expect 0"
+  dut.ana_test.bgap_out.write!(1)
+  dut.ana_test.bgap_out.read!(0)
+
+  if tester.sim?
+    ss "Test reading an X register value, expect LSB nibble to be 0"
+    dut.x_reg[3..0].read!(0)
+  end
+end

--- a/pattern/test.rb
+++ b/pattern/test.rb
@@ -184,9 +184,6 @@ Pattern.create do
     unless dut.parallel_read.data == 0x7707_7077
       OrigenSim.error "PARALLEL_READ register did not sync from simulation"
     end
-
-    #ss "Test reading an X register value"
-    #dut.x_reg.read!(0)
   end
 
   ss "Do some operations with the counter, just for fun"

--- a/templates/rtl_v/origen.v.erb
+++ b/templates/rtl_v/origen.v.erb
@@ -62,7 +62,12 @@ module pin_driver(pin, sync);
   // pin compare failure logger
   always @(posedge error) begin
     //$display("!4![%t] Miscompare on pin %s, expected %d received %d", $time, pin_name, data[0], pin);
-    $bridge_on_miscompare(pin_name, data[0], pin);
+    if (pin == 1'b0 || pin == 1'b1)
+      $bridge_on_miscompare(pin_name, data[0], pin);
+    else if (pin == 1'bz)
+      $bridge_on_miscompare(pin_name, data[0], -2);
+    else
+      $bridge_on_miscompare(pin_name, data[0], -1);
   end
   
   // SMcG - needs more work, causes non-genuine fails in OrigenSim test case


### PR DESCRIPTION
- A better fix for #33, the original attempt broke the failed transaction reporting
- Fix for #37, stops the new stdout reader loop from logging empty lines during shutdown
- Added a new pattern called `fails.rb` which can be run to visually inspect that fail conditions like transaction errors are reporting correctly


