### PR TITLE
Reg fail info

### DIFF
--- a/lib/origen_sim/simulator.rb
+++ b/lib/origen_sim/simulator.rb
@@ -1252,6 +1252,8 @@ module OrigenSim
     end
 
     def clean(net)
+      # substitute ruby syntax ".." for verilog ":"
+      net.gsub!('..', ':')
       if net =~ /^dut\./
         "#{testbench_top}.#{net}"
       else

--- a/lib/origen_sim/tester.rb
+++ b/lib/origen_sim/tester.rb
@@ -5,6 +5,8 @@ module OrigenSim
 
     TEST_PROGRAM_GENERATOR = OrigenSim::Generator
 
+    attr_accessor :out_of_bounds_handler
+
     def initialize(options = {}, &block)
       # Use Origen's collector to allow options to be set either from the options hash, or from the block
       if block_given?
@@ -328,10 +330,19 @@ module OrigenSim
                 end
 
                 diffs.each do |position, expected, received|
-                  if received == -1 || received == -2
-                    reg_or_val[position].unknown = true
+                  if position < reg_or_val.size
+                    if received == -1 || received == -2
+                      reg_or_val[position].unknown = true
+                    else
+                      reg_or_val[position].write(received, force: true)
+                    end
                   else
-                    reg_or_val[position].write(received, force: true)
+                    # This bit position is beyond the bounds of the register
+                    if @out_of_bounds_handler
+                      @out_of_bounds_handler.call(position, received, expected, reg_or_val)
+                    else
+                      Origen.log.error "bit[#{position}] of read operation on #{reg_or_val.path}.#{reg_or_val.name}: expected #{expected} received #{received}"
+                    end
                   end
                 end
 
@@ -345,7 +356,7 @@ module OrigenSim
                 # Put the data back so the application behaves as it would if generating
                 # for a non-simulation tester target
                 diffs.each do |position, expected, received|
-                  reg_or_val[position].write(expected, force: true)
+                  reg_or_val[position].write(expected, force: true) if position < reg_or_val.size
                 end
               end
             end

--- a/lib/origen_sim_dev/dut.rb
+++ b/lib/origen_sim_dev/dut.rb
@@ -170,7 +170,12 @@ module OrigenSimDev
               jtag.write_dr(dr)
               dr.rg_enable.write(0)
               dr.rg_data.copy_all(reg)
-              jtag.read_dr(dr)
+              if !options[:force_out_of_bounds]
+                jtag.read_dr(dr)
+              else
+                expect_val = dr.data + 2**dr.size
+                jtag.read_dr expect_val, size: dr.size + 1
+              end
             end
           end
         end

--- a/pattern/fails.rb
+++ b/pattern/fails.rb
@@ -20,4 +20,16 @@ Pattern.create do
     ss "Test reading an X register value, expect LSB nibble to be 0"
     dut.x_reg[3..0].read!(0)
   end
+
+  ss "Test an out of bounds miscompare"
+  dut.cmd.write!(0x1234_5678)
+  dut.cmd.read!(0x1233_5678, force_out_of_bounds: true)
+
+  ss "Test user out of bounds handler"
+  if tester.sim?
+    tester.out_of_bounds_handler = proc do |position, received, expected, reg|
+      Origen.log.error "User handler hook is working --> #{reg.name}, bit[#{position}]: expected #{expected}, received #{received}"
+    end
+  end
+  dut.cmd.read!(0x1233_5678, force_out_of_bounds: true)
 end

--- a/templates/origen_guides/simulation/debugging.md.erb
+++ b/templates/origen_guides/simulation/debugging.md.erb
@@ -100,6 +100,21 @@ For reference, here is the update that was made to the JTAG driver to support th
 
 If the driver has not provided this then a warning will be output and no received data will be given.
 
+In some cases the protocol being used may generate failed compares that contain bit position meta data 
+that does not map to the register being read. In this case a generic message will be displayed with the 
+bit position that failed along with the register that was being read. It may be desirable to have application 
+specific code interpret these bits (for example if it is a status bit). Origen provides a hook for this. Below 
+is an example of how to implement a custom interpreter.
+
+~~~ruby
+if tester.sim?
+  tester.out_of_bounds_handler = proc do |position, received, expected, reg|
+    Origen.log.error "Got data ouside of #{reg.name} during the transaction, bit[#{position}]: expected #{expected}, received #{received}"
+    Origen.log.error "ECC error during read of #{reg.path}.#{reg.name}" if position == 39
+  end
+end
+~~~
+
 This feature will automatically be enabled for any reads launched via the register object itself, e.g.
 `my_reg.read!`, but not for reads launched by calling the `read_register` method manually,
 e.g. `dut.read_register(my_reg)`.


### PR DESCRIPTION
This is an update to handle cases where a failing bit is outside of the bounds of the register being read. I also added in mapping of ruby syntax to verilog syntax to fix some failing spec tests.