### PR TITLE
Timing update

### DIFF
--- a/lib/origen_sim_dev/dut.rb
+++ b/lib/origen_sim_dev/dut.rb
@@ -35,6 +35,10 @@ module OrigenSimDev
           w.drive 0, at: 0
           w.drive :data, at: 'period / 2'
         end
+        # Generate drive timing that has only a data event which isn't at t0
+        t.wave :din_port do |w|
+          w.drive :data, at: 'period / 2'
+        end
       end
 
       add_reg :dr, 0x0, size: 66 do |reg|

--- a/pattern/test.rb
+++ b/pattern/test.rb
@@ -218,6 +218,13 @@ Pattern.create do
     60.cycles
   end
 
+  ss "Test timing implementation - drive timing, single data event only, not at t0"
+  dut.pins(:din_port).dont_care
+  tester.cycle
+  dut.pins(:din_port).drive! 1
+  dut.pins(:din_port).drive! 0
+  dut.pins(:din_port).drive! 1
+
   ss "Test the command works with static vectors"
   dut.pin(:done).assert!(1)
   dut.pin(:done).dont_care


### PR DESCRIPTION
If there was only 1 drive event, previously the drive would always be placed at time 0 of the cycle unless the previous cycle was not driving. This fixes that bug (I believe).