### PR TITLE
Increase match loop resolution

### DIFF
--- a/lib/origen_sim/tester.rb
+++ b/lib/origen_sim/tester.rb
@@ -264,7 +264,6 @@ module OrigenSim
       end
     end
 
-
     def wait(*args)
       super
       if Origen.running_interactively? ||

--- a/pattern/test.rb
+++ b/pattern/test.rb
@@ -269,7 +269,7 @@ Pattern.create do
   5.cycles
   dut.pin(:done).assert!(0)
   dut.pin(:done).dont_care
-  tester.wait match: true, time_in_cycles: 2000 do
+  tester.wait match: true, time_in_s: 2 do
     dut.pin(:done).assert!(1)
   end
   dut.pin(:done).assert!(1)

--- a/templates/origen_guides/simulation/patterns.md.erb
+++ b/templates/origen_guides/simulation/patterns.md.erb
@@ -28,6 +28,14 @@ normally have two options:
 Both of these are fully supported by OrigenSim, see the
 [Timing and Waiting guide](<%= path "guides/pattern/timing" %>) for more information on these APIs.
 
+<div class="alert alert-info" role="alert"> <strong>A Note on Match Loops</strong>
+  <br>
+  When waiting for a match, the DUT will be polled every 100us by default or timeout / 10 if that
+  is less than 100us.
+  If you need it to poll more often (at the expense of simulation speed) then a `:resolution` option can
+  be supplied in the same way as described for the `sim_delay` method below.
+</div>
+
 However, if your pattern generation flow is going to be supported by simulation, then you also have
 a third option - to derive the required wait time from the simulation itself.
 


### PR DESCRIPTION
Verifying a match loop result is potentially expensive (it runs the Ruby block containing the condition to be matched) and so I didn't want to poll on every simulation cycle while waiting for a match.

The original implementation assumed that the timeout value supplied by the user would be in the ballpark of what time it should take,  and so the poll frequency was set to expected_time (i.e. timeout) / 10.

However, I've since realized that users who don't know what the time should be (myself included), can put in large timeout values like 1s and then be puzzled over why the match loop blocks the simulation unnecessarily for 100ms if the match condition has become true straight away.

This change puts in a new default poll time of 100us, and if the old calculation resulted in a poll of < 100us, then that will be used instead.
Users can still specify the poll time directly if they find that the default is not fine grained enough or vice versa.
