### PR TITLE
Fix hard coded pin paths at different locations making use of the testbench_top variable

### DIFF
--- a/lib/origen_sim/origen_testers/api.rb
+++ b/lib/origen_sim/origen_testers/api.rb
@@ -89,7 +89,7 @@ module OrigenTesters
       options = pins.last.is_a?(Hash) ? pins.pop : {}
       pins = pins.map { |p| p.is_a?(String) || p.is_a?(Symbol) ? dut.pin(p) : p }
       pins.each(&:save)
-      @sim_capture = pins.map { |p| [p, "origen.dut.#{p.rtl_name}"] }
+      @sim_capture = pins.map { |p| [p, "#{simulator.testbench_top || 'origen'}.dut.#{p.rtl_name}"] }
       Origen::OrgFile.open(id, path: OrigenSim.capture_dir) do |org_file|
         @org_file = org_file
         @update_capture = update_capture?

--- a/templates/probe.tcl.erb
+++ b/templates/probe.tcl.erb
@@ -7,11 +7,11 @@ probe -create -shm <%= options[:testbench_top] || 'origen' %> -depth <%= options
 
 % Hash(options[:force]).each do |net, value|
 %   net = net.to_s.strip.sub(/^(origen\.|origen\.dut\.|\.)/, '')
-force origen.dut.<%= net %> <%= value %>
+force <%= options[:testbench_top] || 'origen' %>.dut.<%= net %> <%= value %>
 % end
 
 % (options[:setup] || '').split("\n").each do |line|
-<%= line.strip.gsub(" dut", " origen.dut") %>
+<%= line.strip.gsub(" dut", " #{options[:testbench_top] || 'origen'}.dut") %>
 % end
 
 run


### PR DESCRIPTION
Hi All,

Needed to add the options[:testbench_top] called also for forced signals in the template/probe.tcl.erb.
I also modified the origen_sim/origen_tester/api.rb, which also has a hard coded 'origen.dut' in the sim_capture function.

So the hard coded path: origen.dut or origen.debug is now removed from the template/probe.tcl
I noticed it is also present at other locations: like in template/empty.svcf (and others), which makes that default setup signals cannot be found, in case a different testbench_top is used (i.o. 'origen') => problem is that this emty.svcf (and others) is not an .erb file, and is not compiled in origen_sim => it would be nice to have that implemented, but I am not sure how.
